### PR TITLE
Initial refactor to use network ticks instead of change ticks

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,7 @@ use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeSeed, Deserialize, Serialize};
 
 use crate::{
-    tick::Tick,
+    tick::NetworkTick,
     world_diff::{ComponentDiff, WorldDiff, WorldDiffDeserializer},
     Replication, REPLICATION_CHANNEL_ID,
 };
@@ -63,7 +63,7 @@ impl ClientPlugin {
 
     fn world_diff_receiving_system(
         mut commands: Commands,
-        mut last_tick: ResMut<LastTick>,
+        mut tick: ResMut<LastTick>,
         mut client: ResMut<RenetClient>,
         registry: Res<AppTypeRegistry>,
     ) {
@@ -105,14 +105,8 @@ pub enum ClientState {
 /// Last received tick from server.
 ///
 /// Exists only on clients, sent to the server.
-#[derive(Resource, Serialize, Deserialize, Deref, DerefMut)]
-pub(super) struct LastTick(pub(super) Tick);
-
-impl Default for LastTick {
-    fn default() -> Self {
-        Self(Tick::new(0))
-    }
-}
+#[derive(Resource, Default, Serialize, Deserialize, Deref, DerefMut)]
+pub struct LastTick(pub(super) NetworkTick);
 
 trait ApplyWorldDiffExt {
     fn apply_world_diff(&mut self, world_diff: WorldDiff);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,13 +344,13 @@ creation / connection systems and corresponding UI.
 #![doc = include_str!("../README.md")]
 
 pub mod client;
+pub mod tick;
 pub mod network_event;
 pub mod parent_sync;
 pub mod replication_core;
 pub mod server;
 #[cfg(test)]
 mod test_network;
-mod tick;
 mod world_diff;
 
 pub mod prelude {

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,6 +24,7 @@ use tap::TapFallible;
 use crate::{
     client::LastTick,
     replication_core::ReplicationRules,
+    tick::NetworkTick,
     tick::Tick,
     world_diff::{ComponentDiff, WorldDiff, WorldDiffSerializer},
     REPLICATION_CHANNEL_ID,
@@ -110,7 +111,7 @@ impl ServerPlugin {
         let registry = registry.read();
         let mut client_diffs: HashMap<_, _> = acked_ticks
             .iter()
-            .map(|(&client_id, &last_tick)| (client_id, WorldDiff::new(last_tick)))
+            .map(|(&client_id, &last_tick)| (client_id, WorldDiff::new(last_tick.get())))
             .collect();
         collect_changes(&mut client_diffs, set.p0(), &registry, &replication_rules);
         collect_removals(&mut client_diffs, set.p0(), &change_tick, &removal_trackers);
@@ -320,4 +321,4 @@ pub enum ServerState {
 ///
 /// Used only on server.
 #[derive(Default, Deref, DerefMut, Resource)]
-pub(super) struct AckedTicks(HashMap<u64, Tick>);
+pub(super) struct AckedTicks(HashMap<u64, NetworkTick>);

--- a/src/server/removal_tracker.rs
+++ b/src/server/removal_tracker.rs
@@ -8,7 +8,7 @@ use super::AckedTicks;
 use crate::{
     replication_core::{Replication, ReplicationRules},
     server::ServerState,
-    tick::Tick,
+    tick::NetworkTick,
 };
 
 /// Stores component removals in [`RemovalTracker`] component to make them persistent across ticks.
@@ -71,7 +71,7 @@ impl RemovalTrackerPlugin {
 }
 
 #[derive(Component, Default, Deref, DerefMut)]
-pub(crate) struct RemovalTracker(pub(crate) HashMap<ComponentId, Tick>);
+pub(crate) struct RemovalTracker(pub(crate) HashMap<ComponentId, NetworkTick>);
 
 #[cfg(test)]
 mod tests {
@@ -98,7 +98,7 @@ mod tests {
         const DUMMY_CLIENT_ID: u64 = 0;
         app.world
             .resource_mut::<AckedTicks>()
-            .insert(DUMMY_CLIENT_ID, Tick::new(0));
+            .insert(DUMMY_CLIENT_ID, Default::default());
 
         let replicated_entity = app.world.spawn((Transform::default(), Replication)).id();
 

--- a/src/tick.rs
+++ b/src/tick.rs
@@ -1,51 +1,46 @@
-//! A copy of `Tick` from Bevy latest master to achieve type safety.
-
-use bevy::ecs::change_detection::MAX_CHANGE_AGE;
+use bevy::{prelude::*, reflect::FromReflect};
 use serde::{Deserialize, Serialize};
 
-/// A value that tracks when a system ran relative to other systems.
-/// This is used to power change detection.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-pub struct Tick {
-    tick: u32,
-}
+/// Tick to communicate the game's timeline between client and server.
+#[derive(
+    Resource,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    Reflect,
+    FromReflect,
+)]
+pub struct NetworkTick(u64);
 
-impl Tick {
-    pub const fn new(tick: u32) -> Self {
-        Self { tick }
-    }
-
-    /// Gets the value of this change tick.
-    #[inline]
-    pub const fn get(self) -> u32 {
-        self.tick
-    }
-
-    /// Sets the value of this change tick.
-    #[inline]
-    pub fn set(&mut self, tick: u32) {
-        self.tick = tick;
-    }
-
-    /// Returns `true` if this `Tick` occurred since the system's `last_run`.
-    ///
-    /// `this_run` is the current tick of the system, used as a reference to help deal with wraparound.
-    #[inline]
-    pub fn is_newer_than(self, last_run: Tick, this_run: Tick) -> bool {
-        // This works even with wraparound because the world tick (`this_run`) is always "newer" than
-        // `last_run` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values
-        // so they never get older than `u32::MAX` (the difference would overflow).
-        //
-        // The clamp here ensures determinism (since scans could differ between app runs).
-        let ticks_since_insert = this_run.relative_to(self).tick.min(MAX_CHANGE_AGE);
-        let ticks_since_system = this_run.relative_to(last_run).tick.min(MAX_CHANGE_AGE);
-
-        ticks_since_system > ticks_since_insert
-    }
-
-    /// Returns a change tick representing the relationship between `self` and `other`.
-    pub(crate) fn relative_to(self, other: Self) -> Self {
-        let tick = self.tick.wrapping_sub(other.tick);
-        Self { tick }
+impl Default for NetworkTick {
+    fn default() -> Self {
+        Self::new(0)
     }
 }
+
+impl NetworkTick {
+    pub fn new(tick: u64) -> Self {
+        Self(tick)
+    }
+
+    pub fn increment(&mut self) {
+        self.0 += 1;
+    }
+
+    pub fn set_tick(&mut self, tick: u64) {
+        self.0 = tick;
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+pub struct NetworkTickMap(HashMap<NetworkTick, u32>);

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -19,34 +19,26 @@ use serde::{
 };
 use strum::{EnumDiscriminants, EnumVariantNames, IntoStaticStr, VariantNames};
 
-use crate::tick::Tick;
+use crate::tick::NetworkTick;
 
 /// Changed world data and current tick from server.
 ///
 /// Sent from server to clients.
-pub(super) struct WorldDiff {
-    pub(super) tick: Tick,
-    pub(super) entities: HashMap<Entity, Vec<ComponentDiff>>,
-    pub(super) despawns: Vec<Entity>,
+pub struct WorldDiff {
+    pub tick: NetworkTick,
+    pub entities: HashMap<Entity, Vec<ComponentDiff>>,
+    pub despawns: Vec<Entity>,
 }
 
 impl WorldDiff {
     /// Creates a new [`WorldDiff`] with a tick and empty entities.
-    pub(super) fn new(tick: Tick) -> Self {
+    pub fn new(tick: NetworkTick) -> Self {
         Self {
             tick,
             entities: Default::default(),
             despawns: Default::default(),
         }
     }
-}
-
-/// Fields of [`WorldDiff`] for manual deserialization.
-#[derive(Deserialize, IntoStaticStr, EnumVariantNames)]
-enum WorldDiffField {
-    Tick,
-    Entities,
-    Despawned,
 }
 
 /// Type of component or resource change.
@@ -70,6 +62,14 @@ impl ComponentDiff {
             ComponentDiff::Removed(type_name) => type_name,
         }
     }
+}
+
+/// Fields of [`WorldDiff`] for manual deserialization.
+#[derive(Deserialize, IntoStaticStr, EnumVariantNames)]
+enum WorldDiffField {
+    Tick,
+    Entities,
+    Despawned,
 }
 
 #[derive(Constructor)]


### PR DESCRIPTION
Not done yet, will need to refactor some other things.

I think ideally we check for removal/despawns each server tick rather than each frame.