### PR TITLE
Use renet master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 include = ["/src", "/LICENSE*"]
 
 [dependencies]
-bevy_renet = "0.0.7"
+bevy_renet = { git = "https://github.com/lucaspoffo/renet" }
 bevy = { version = "0.10.1", default-features = false, features = [
   "bevy_scene",
 ] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,7 @@ use bevy::{
     reflect::TypeRegistryInternal,
     utils::HashMap,
 };
-use bevy_renet::transport::client_connected;
+use bevy_renet::transport::{client_connected, client_connecting};
 use bevy_renet::{renet::RenetClient, RenetClientPlugin};
 use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeSeed, Deserialize, Serialize};
@@ -16,12 +16,12 @@ use crate::{
     Replication, REPLICATION_CHANNEL_ID,
 };
 
-pub fn client_connecting(client: Option<Res<RenetClient>>) -> bool {
-    match client {
-        Some(client) => client.is_connected(),
-        None => false,
-    }
-}
+// pub fn client_connecting(client: Option<Res<RenetClient>>) -> bool {
+//     match client {
+//         Some(client) => client.,
+//         None => false,
+//     }
+// }
 
 pub struct ClientPlugin;
 
@@ -35,7 +35,7 @@ impl Plugin for ClientPlugin {
                 (
                     Self::no_connection_state_system.run_if(resource_removed::<RenetClient>()),
                     Self::connecting_state_system
-                        .run_if(client_connected)
+                        .run_if(client_connecting)
                         .run_if(state_exists_and_equals(ClientState::NoConnection)),
                     Self::connected_state_system
                         .run_if(client_connected)

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use bevy::{
     reflect::TypeRegistryInternal,
     utils::HashMap,
 };
+use bevy_renet::transport::client_connected;
 use bevy_renet::{renet::RenetClient, RenetClientPlugin};
 use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeSeed, Deserialize, Serialize};
@@ -19,7 +20,7 @@ pub struct ClientPlugin;
 
 impl Plugin for ClientPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(RenetClientPlugin::default())
+        app.add_plugin(RenetClientPlugin {})
             .add_state::<ClientState>()
             .init_resource::<LastTick>()
             .init_resource::<NetworkEntityMap>()
@@ -27,10 +28,10 @@ impl Plugin for ClientPlugin {
                 (
                     Self::no_connection_state_system.run_if(resource_removed::<RenetClient>()),
                     Self::connecting_state_system
-                        .run_if(bevy_renet::client_connecting)
+                        .run_if(bevy_renet)
                         .run_if(state_exists_and_equals(ClientState::NoConnection)),
                     Self::connected_state_system
-                        .run_if(bevy_renet::client_connected)
+                        .run_if(client_connected)
                         .run_if(state_exists_and_equals(ClientState::Connecting)),
                 )
                     .before(run_enter_schedule::<ClientState>)

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,13 @@ use crate::{
     Replication, REPLICATION_CHANNEL_ID,
 };
 
+pub fn client_connecting(client: Option<Res<RenetClient>>) -> bool {
+    match client {
+        Some(client) => client.is_connected(),
+        None => false,
+    }
+}
+
 pub struct ClientPlugin;
 
 impl Plugin for ClientPlugin {
@@ -28,7 +35,7 @@ impl Plugin for ClientPlugin {
                 (
                     Self::no_connection_state_system.run_if(resource_removed::<RenetClient>()),
                     Self::connecting_state_system
-                        .run_if(bevy_renet)
+                        .run_if(client_connected)
                         .run_if(state_exists_and_equals(ClientState::NoConnection)),
                     Self::connected_state_system
                         .run_if(client_connected)

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -215,7 +215,7 @@ fn receiving_system<T: Event + DeserializeOwned + Debug>(
     mut server: ResMut<RenetServer>,
     channel: Res<EventChannel<T>>,
 ) {
-    for client_id in server.clients_id() {
+    for client_id in server.connections_id() {
         while let Some(message) = server.receive_message(client_id, channel.id) {
             match bincode::deserialize(&message) {
                 Ok(event) => {
@@ -239,7 +239,7 @@ fn receiving_reflect_system<T, D>(
     for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
 {
     let registry = registry.read();
-    for client_id in server.clients_id() {
+    for client_id in server.connections_id() {
         while let Some(message) = server.receive_message(client_id, channel.id) {
             // Set options to match `bincode::serialize`.
             // https://docs.rs/bincode/latest/bincode/config/index.html#options-struct-vs-bincode-functions

--- a/src/replication_core.rs
+++ b/src/replication_core.rs
@@ -71,7 +71,7 @@ fn channel_configs(events_count: u8, is_client: bool) -> Vec<ChannelConfig> {
             channel_configs.push(ChannelConfig {
                 channel_id: REPLICATION_CHANNEL_ID + channel_id,
                 max_memory_usage_bytes: 5 * 1024 * 1024,
-                send_type: SendType::ReliableOrdered { resend_time: Duration::ZERO },
+                send_type: SendType::ReliableOrdered { resend_time: Duration::from_millis(300) },
             });
             // channel_configs.push(ChannelConfig::Reliable(ReliableChannelConfig {
             //     channel_id: REPLICATION_CHANNEL_ID + channel_id,
@@ -89,7 +89,7 @@ fn channel_configs(events_count: u8, is_client: bool) -> Vec<ChannelConfig> {
             channel_configs.push(ChannelConfig {
                 channel_id: REPLICATION_CHANNEL_ID + channel_id,
                 max_memory_usage_bytes: 10 * 1024 * 1024,
-                send_type: SendType::ReliableOrdered { resend_time: Duration::ZERO },
+                send_type: SendType::ReliableOrdered { resend_time: Duration::from_millis(300) },
             });
         }
         channel_configs

--- a/src/server.rs
+++ b/src/server.rs
@@ -48,7 +48,7 @@ impl Default for ServerPlugin {
 
 impl Plugin for ServerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(RenetServerPlugin::default())
+        app.add_plugin(RenetServerPlugin {})
             .add_plugin(RemovalTrackerPlugin)
             .add_plugin(DespawnTrackerPlugin)
             .configure_set(ServerSet::Authority.run_if(not(resource_exists::<RenetClient>())))
@@ -135,7 +135,7 @@ impl ServerPlugin {
         mut acked_ticks: ResMut<AckedTicks>,
         mut server: ResMut<RenetServer>,
     ) {
-        for client_id in server.clients_id() {
+        for client_id in server.connections_id() {
             let mut last_message = None;
             while let Some(message) = server.receive_message(client_id, REPLICATION_CHANNEL_ID) {
                 last_message = Some(message);
@@ -157,7 +157,7 @@ impl ServerPlugin {
         mut acked_ticks: ResMut<AckedTicks>,
     ) {
         for event in &mut server_events {
-            if let ServerEvent::ClientDisconnected(id) = event {
+            if let ServerEvent::ClientDisconnected { client_id: id, reason: _ } = event {
                 acked_ticks.remove(id);
             }
         }


### PR DESCRIPTION
I talked to Shatur on discord about this issue, I personally don't quite understand it but I tried updating replicon to use renet main branch. I fixed all but one compile error, which you can see below.
```
Compiling bevy_replicon v0.3.0 (D:\BevyProjects\bevy_replicon-use-renet-master)
error[E0425]: cannot find value `client_connecting` in crate `bevy_renet`
  --> src\client.rs:31:45
   |
31 |                         .run_if(bevy_renet::client_connecting)
   |                                             ^^^^^^^^^^^^^^^^^ not found in `bevy_renet`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `bevy_replicon` due to previous error
```