### PR TITLE
Move tick configuration to ServerTickPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update server to use `TickPolicy` instead of requiring a tick rate.
+
 ## [0.4.0] - 2023-05-26
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ plugins to let you host and join games from the same application. If you
 planning to separate client and server you can use
 [`PluginGroupBuilder::disable()`] to disable [`ClientPlugin`] or
 [`ServerPlugin`]. You can also configure how often updates are sent from
-server to clients:
+server to clients with [`ServerPlugin`]'s [`TickPolicy`].:
 
 ```rust
 # use bevy::prelude::*;
@@ -34,7 +34,7 @@ app.add_plugins(MinimalPlugins).add_plugins(
     ReplicationPlugins
         .build()
         .disable::<ClientPlugin>()
-        .set(ServerPlugin { tick_rate: 60 }),
+        .set(ServerPlugin { tick_policy: TickPolicy::MaxTickRate(60) }),
 );
 ```
 
@@ -371,7 +371,7 @@ pub mod prelude {
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},
         replication_core::{AppReplicationExt, NetworkChannels, Replication, ReplicationRules},
-        server::{ServerPlugin, ServerSet, ServerState, SERVER_ID},
+        server::{ServerPlugin, ServerSet, ServerState, TickPolicy, SERVER_ID},
         ReplicationPlugins,
     };
 }


### PR DESCRIPTION
Moves timer-based tick configuration to `ServerTickPlugin` so that `ServerSet::Tick` can be manually configured if needed.