### PR TITLE
Server event sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update server to use `TickPolicy` instead of requiring a tick rate.
+- Add `ServerSet::ReceiveEvent` and `ServerSet::SendEvent` for more fine-grained control of scheduling for event handling.
 
 ## [0.4.0] - 2023-05-26
 

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -112,9 +112,17 @@ impl ClientEventAppExt for App {
         self.add_event::<T>()
             .add_event::<FromClient<T>>()
             .insert_resource(EventChannel::<T>::new(channel_id))
-            .add_system(sending_system.in_set(OnUpdate(ClientState::Connected)))
+            .add_system(
+                sending_system
+                    .in_set(ServerSet::SendEvents)
+                    .run_if(in_state(ClientState::Connected)),
+            )
             .add_system(local_resending_system::<T>.in_set(ServerSet::Authority))
-            .add_system(receiving_system.in_set(OnUpdate(ServerState::Hosting)));
+            .add_system(
+                receiving_system
+                    .in_set(ServerSet::ReceiveEvents)
+                    .run_if(in_state(ServerState::Hosting)),
+            );
 
         self
     }

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -112,10 +112,16 @@ impl ServerEventAppExt for App {
         self.add_event::<T>()
             .init_resource::<Events<ToClients<T>>>()
             .insert_resource(EventChannel::<T>::new(channel_id))
-            .add_system(receiving_system.in_set(OnUpdate(ClientState::Connected)))
+            .add_system(
+                receiving_system
+                    .in_set(ServerSet::ReceiveEvents)
+                    .run_if(in_state(ClientState::Connected)),
+            )
             .add_systems(
                 (
-                    sending_system.in_set(OnUpdate(ServerState::Hosting)),
+                    sending_system
+                        .in_set(ServerSet::SendEvents)
+                        .run_if(in_state(ServerState::Hosting)),
                     local_resending_system::<T>.in_set(ServerSet::Authority),
                 )
                     .chain()

--- a/src/server.rs
+++ b/src/server.rs
@@ -337,6 +337,10 @@ pub enum ServerSet {
     Authority,
     /// Runs on server tick.
     Tick,
+    /// Runs when events can be received.
+    ReceiveEvents,
+    /// Runs when events can be sent.
+    SendEvents,
 }
 
 #[derive(States, Clone, Copy, Debug, Eq, Hash, PartialEq, Default)]


### PR DESCRIPTION
Use server sets for controlling when event receiving/sending systems run so they can be configured by the user.

Resolves #12.