### PR TITLE
Clean up tick ack and world diff system ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update server to use `TickPolicy` instead of requiring a tick rate.
 - Add `ServerSet::ReceiveEvent` and `ServerSet::SendEvent` for more fine-grained control of scheduling for event handling.
 
+### Fixed
+
+- Unspecified system ordering could cause tick acks to be ordered on the wrong side of world diff handling.
+
 ## [0.4.0] - 2023-05-26
 
 ### Changed

--- a/src/client.rs
+++ b/src/client.rs
@@ -45,9 +45,10 @@ impl Plugin for ClientPlugin {
             .add_system(Self::client_reset_system.in_schedule(OnExit(ClientState::Connected)))
             .add_systems(
                 (
-                    Self::tick_ack_sending_system,
                     Self::world_diff_receiving_system,
+                    Self::tick_ack_sending_system,
                 )
+                    .chain()
                     .in_set(OnUpdate(ClientState::Connected)),
             );
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -81,19 +81,16 @@ impl Plugin for ServerPlugin {
                     .before(run_enter_schedule::<ServerState>)
                     .in_base_set(CoreSet::StateTransitions),
             )
+            .add_system(Self::server_reset_system.in_schedule(OnExit(ServerState::Hosting)))
             .add_systems(
                 (
                     Self::tick_acks_receiving_system,
                     Self::acked_ticks_cleanup_system,
+                    Self::world_diffs_sending_system.in_set(ServerSet::Tick),
                 )
+                    .chain()
                     .in_set(OnUpdate(ServerState::Hosting)),
-            )
-            .add_systems((
-                Self::world_diffs_sending_system
-                    .in_set(OnUpdate(ServerState::Hosting))
-                    .in_set(ServerSet::Tick),
-                Self::server_reset_system.in_schedule(OnExit(ServerState::Hosting)),
-            ));
+            );
 
         // Remove delay for tests.
         if cfg!(not(test)) {


### PR DESCRIPTION
Server: we want to collect acks before sending world diffs.
Client: we want to collect world diffs before sending acks.