### PR TITLE
Add ReplicationCorePlugin to public interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,10 @@ pub mod prelude {
         },
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},
-        replication_core::{AppReplicationExt, NetworkChannels, Replication, ReplicationRules},
+        replication_core::{
+            AppReplicationExt, NetworkChannels, Replication, ReplicationCorePlugin,
+            ReplicationRules,
+        },
         server::{ServerPlugin, ServerSet, ServerState, TickPolicy, SERVER_ID},
         ReplicationPlugins,
     };
@@ -379,7 +382,6 @@ pub mod prelude {
 use bevy::{app::PluginGroupBuilder, prelude::*};
 pub use bevy_renet::renet;
 use prelude::*;
-use replication_core::ReplicationCorePlugin;
 
 const REPLICATION_CHANNEL_ID: u8 = 0;
 

--- a/src/replication_core.rs
+++ b/src/replication_core.rs
@@ -10,7 +10,7 @@ use bevy_renet::renet::{ChannelConfig, SendType};
 
 use crate::REPLICATION_CHANNEL_ID;
 
-pub(super) struct ReplicationCorePlugin;
+pub struct ReplicationCorePlugin;
 
 impl Plugin for ReplicationCorePlugin {
     fn build(&self, app: &mut App) {


### PR DESCRIPTION
The `ReplicationCorePlugin` plugin is required to register types for replication. If a crate only registers types for replication then it can't be unit tested without this plugin (or manually reproducing this plugin), but other plugins in `ReplicationPlugins` are not needed.
