### PR TITLE
Add send policy (ordered vs unordered) to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SendPolicy` added to API of event-creation for user control of delivery guarantee (reliability and ordering).
+
 ## [0.5.0] - 2023-06-26
 
 ### Added

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -49,7 +49,7 @@ impl Plugin for TicTacToePlugin {
             .replicate::<Symbol>()
             .replicate::<BoardCell>()
             .replicate::<Player>()
-            .add_client_event::<CellPick>()
+            .add_client_event::<CellPick>(SendPolicy::Ordered)
             .insert_resource(ClearColor(BACKGROUND_COLOR))
             .add_startup_systems((
                 Self::ui_setup_system,


### PR DESCRIPTION
Currently event channels are ordered-reliable, which means they will block if any single event gets dropped by the network. For events that don't need to be ordered, it would be nice to gain some efficiency (especially for high-volume channels).