### PR TITLE
Refactor replication to use a buffer cache

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use bevy_renet::transport::client_connected;
 use bevy_renet::{renet::RenetClient, transport::NetcodeClientPlugin, RenetClientPlugin};
 
 use crate::{
-    replicon_core::{Mapper, NetworkTick, WorldDiff, REPLICATION_CHANNEL_ID},
+    replicon_core::{deserialize_to_world, Mapper, NetworkTick, REPLICATION_CHANNEL_ID},
     Replication,
 };
 
@@ -48,7 +48,7 @@ impl ClientPlugin {
     fn diff_receiving_system(world: &mut World) {
         world.resource_scope(|world, mut client: Mut<RenetClient>| {
             while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
-                WorldDiff::deserialize_to_world(world, message)
+                deserialize_to_world(world, message)
                     .expect("server should send only valid world diffs");
             }
         });


### PR DESCRIPTION
### Problem

When servers build a replication diff, they allocate many times to collect an intermediate representation of the message. This is quite inefficient.

### Solution

Use a buffer for the intermediate representation so allocations are greatly reduced. We still have allocations when new entities are introduced.

I saw a 40% speedup in the 'entities send' benchmark, and 6% in the 'entities receive' benchmark. I did not examine packet sizes, although I expect them to be smaller due to some optimizations around entity and replication ids.

This PR depends on #41.

### Follow-up

The replication buffer should have a queue of `ComponentData`s collected from despawned entities for reuse with new entities. In that case the long-run upper limit on buffer size will be: O(max entities * max entity size).

The buffer currently limits apps to 65k replicable entities and 127 replicable components per entity. It may be possible to configure those values at compile time.

Entities can be serialized as two u32 varints instead of a u64 varint, which should save 1-3 bytes per entity since entities are actually two u32s concatenated.
