### PR TITLE
Make ReplicationRules::get_info crate-private for safety

### DIFF
--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -168,7 +168,7 @@ impl ReplicationRules {
     }
 
     /// Returns meta information about replicated component.
-    pub fn get_info(&self, replication_id: ReplicationId) -> &ReplicationInfo {
+    pub(super) fn get_info(&self, replication_id: ReplicationId) -> &ReplicationInfo {
         // SAFETY: `ReplicationId` always corresponds to a valid index.
         unsafe { self.info.get_unchecked(replication_id.0) }
     }


### PR DESCRIPTION
### Problem

`ReplicationRules::get_info()` is unsafe if you use an unknown replication id, which may come from an invalid serialization (since the replication id itself is crate-private).

### Solution

Mark it with `pub(super)`.
