### PR TITLE
Trim empty arrays in message

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,8 +54,8 @@ impl ClientPlugin {
             world.resource_scope(|world, mut entity_map: Mut<NetworkEntityMap>| {
                 world.resource_scope(|world, replication_rules: Mut<ReplicationRules>| {
                     while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
+                        let end_pos = message.len().try_into().unwrap();
                         let mut cursor = Cursor::new(message);
-                        let end_pos = cursor.get_ref().len().try_into().unwrap();
 
                         if !deserialize_tick(&mut cursor, world)? {
                             continue;


### PR DESCRIPTION
Saves some space when there are no despawns, no despawns and removals or no changes at all.