### PR TITLE
Refactor entity serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Serialize entities in optimal way by writing its index and generation as separate varints.
 - Hide `ReplicationId`, `ReplicationInfo` and related methods from `ReplicationRules` from public API.
 - Rename `ReplicationRules::replication_id` into `ReplicationRules::replication_marker_id`.
 - Use serialization buffer cache per client for replication.

--- a/src/client.rs
+++ b/src/client.rs
@@ -122,7 +122,7 @@ fn deserialize_tick(cursor: &mut Cursor<Bytes>, world: &mut World) -> Result<boo
     }
 }
 
-/// Deserializes component [`DiffKind`] and applies them to the [`World`].
+/// Deserializes component diffs of `diff_kind` and applies them to the `world`.
 fn deserialize_component_diffs(
     cursor: &mut Cursor<Bytes>,
     world: &mut World,
@@ -132,7 +132,7 @@ fn deserialize_component_diffs(
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
     for _ in 0..entities_count {
-        let entity = DefaultOptions::new().deserialize_from(&mut *cursor)?;
+        let entity = deserialize_entity(&mut *cursor)?;
         let mut entity = entity_map.get_by_server_or_spawn(world, entity);
         let components_count: u8 = bincode::deserialize_from(&mut *cursor)?;
         for _ in 0..components_count {
@@ -150,7 +150,7 @@ fn deserialize_component_diffs(
     Ok(())
 }
 
-/// Deserializes despawns and applies them to the [`World`].
+/// Deserializes despawns and applies them to the `world`.
 fn deserialize_despawns(
     cursor: &mut Cursor<Bytes>,
     world: &mut World,
@@ -161,13 +161,22 @@ fn deserialize_despawns(
         // The entity might have already been deleted with the last diff,
         // but the server might not yet have received confirmation from the
         // client and could include the deletion in the latest diff.
-        let server_entity = DefaultOptions::new().deserialize_from(&mut *cursor)?;
+        let server_entity = deserialize_entity(&mut *cursor)?;
         if let Some(client_entity) = entity_map.remove_by_server(server_entity) {
             world.entity_mut(client_entity).despawn_recursive();
         }
     }
 
     Ok(())
+}
+
+/// Deserializes `entity` from index and generation that was separately serialized as varints.
+fn deserialize_entity(cursor: &mut Cursor<Bytes>) -> Result<Entity, bincode::Error> {
+    let index: u32 = DefaultOptions::new().deserialize_from(&mut *cursor)?;
+    let generation: u32 = DefaultOptions::new().deserialize_from(&mut *cursor)?;
+    let bits = (generation as u64) << 32 | index as u64;
+
+    Ok(Entity::from_bits(bits))
 }
 
 /// Type of component change.

--- a/src/client.rs
+++ b/src/client.rs
@@ -170,20 +170,16 @@ fn deserialize_despawns(
     Ok(())
 }
 
-/// Deserializes `entity` from compressed index and generation (see [`ReplicationBuffer::write_entity()`].
+/// Deserializes `entity` from compressed index and generation, for details see [`ReplicationBuffer::write_entity()`].
 fn deserialize_entity(cursor: &mut Cursor<Bytes>) -> Result<Entity, bincode::Error> {
-    // deserialize flagged entity index
     let flagged_index: u64 = DefaultOptions::new().deserialize_from(&mut *cursor)?;
-    let has_generation = (flagged_index & (1u64)) > 0;
-
-    // get entity generation
+    let has_generation = (flagged_index & 1) > 0;
     let generation = if has_generation {
         DefaultOptions::new().deserialize_from(&mut *cursor)?
     } else {
         0u32
     };
 
-    // finalize entity
     let bits = (generation as u64) << 32 | (flagged_index >> 1);
 
     Ok(Entity::from_bits(bits))

--- a/src/server.rs
+++ b/src/server.rs
@@ -648,10 +648,18 @@ impl ReplicationBuffer {
         Ok(())
     }
 
-    /// Serializes `entity` in optimal way by writing its index and generation as separate varints.
+    /// Serializes `entity` by writing its index and generation as separate varints. The index is first
+    /// prepended with a bit flag to indicate if the generation is serialized or not (it is not serialized if
+    /// equal to zero).
+    #[inline]
     fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
-        DefaultOptions::new().serialize_into(&mut self.message, &entity.index())?;
-        DefaultOptions::new().serialize_into(&mut self.message, &entity.generation())?;
+        let mut flagged_index = (entity.index() as u64) << 1;
+        let flag = entity.generation() > 0;
+        flagged_index |= flag as u64;
+        DefaultOptions::new().serialize_into(&mut self.message, &flagged_index)?;
+        if flag {
+            DefaultOptions::new().serialize_into(&mut self.message, &entity.generation())?;
+        }
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -648,14 +648,16 @@ impl ReplicationBuffer {
         Ok(())
     }
 
-    /// Serializes `entity` by writing its index and generation as separate varints. The index is first
-    /// prepended with a bit flag to indicate if the generation is serialized or not (it is not serialized if
-    /// equal to zero).
+    /// Serializes `entity` by writing its index and generation as separate varints.
+    ///
+    /// The index is first prepended with a bit flag to indicate if the generation
+    /// is serialized or not (it is not serialized if equal to zero).
     #[inline]
     fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
         let mut flagged_index = (entity.index() as u64) << 1;
         let flag = entity.generation() > 0;
         flagged_index |= flag as u64;
+
         DefaultOptions::new().serialize_into(&mut self.message, &flagged_index)?;
         if flag {
             DefaultOptions::new().serialize_into(&mut self.message, &entity.generation())?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -648,7 +648,7 @@ impl ReplicationBuffer {
         Ok(())
     }
 
-    /// Serializes `entity` in optimal way by writing its index and generation as separate u32 varints.
+    /// Serializes `entity` in optimal way by writing its index and generation as separate varints.
     fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
         DefaultOptions::new().serialize_into(&mut self.message, &entity.index())?;
         DefaultOptions::new().serialize_into(&mut self.message, &entity.generation())?;


### PR DESCRIPTION
Serializes entities in optimal way by writing
its index and generation as separate u32 varints.

Also update related docs. Looks like in Rust documentation they don't link types that are already in signature and refer to variable names which is make sense.