### PR TITLE
Add `#[inline]` to trivial functions and remove from private ones

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -225,6 +225,7 @@ pub struct NetworkEntityMap {
 }
 
 impl NetworkEntityMap {
+    #[inline]
     pub fn insert(&mut self, server_entity: Entity, client_entity: Entity) {
         self.server_to_client.insert(server_entity, client_entity);
         self.client_to_server.insert(client_entity, server_entity);
@@ -255,10 +256,12 @@ impl NetworkEntityMap {
         client_entity
     }
 
+    #[inline]
     pub fn to_client(&self) -> &HashMap<Entity, Entity> {
         &self.server_to_client
     }
 
+    #[inline]
     pub fn to_server(&self) -> &HashMap<Entity, Entity> {
         &self.client_to_server
     }
@@ -279,6 +282,7 @@ pub struct ClientMapper<'a> {
 }
 
 impl<'a> ClientMapper<'a> {
+    #[inline]
     pub fn new(world: &'a mut World, entity_map: &'a mut NetworkEntityMap) -> Self {
         Self {
             world,

--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -173,7 +173,6 @@ impl ReplicationRules {
     }
 
     /// Returns mapping of replicated components to their replication IDs.
-    #[inline]
     pub(super) fn get_ids(&self) -> &HashMap<ComponentId, ReplicationId> {
         &self.ids
     }
@@ -301,11 +300,13 @@ pub struct NetworkTick(u32);
 
 impl NetworkTick {
     /// Creates a new [`NetworkTick`] wrapping the given value.
+    #[inline]
     pub fn new(value: u32) -> Self {
         Self(value)
     }
 
     /// Gets the value of this network tick.
+    #[inline]
     pub fn get(self) -> u32 {
         self.0
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -409,11 +409,13 @@ impl ServerTicks {
     }
 
     /// Returns current server tick.
+    #[inline]
     pub fn current_tick(&self) -> NetworkTick {
         self.current_tick
     }
 
     /// Returns last acknowledged server ticks for all clients.
+    #[inline]
     pub fn acked_ticks(&self) -> &HashMap<u64, NetworkTick> {
         &self.acked_ticks
     }
@@ -652,7 +654,6 @@ impl ReplicationBuffer {
     ///
     /// The index is first prepended with a bit flag to indicate if the generation
     /// is serialized or not (it is not serialized if equal to zero).
-    #[inline]
     fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
         let mut flagged_index = (entity.index() as u64) << 1;
         let flag = entity.generation() > 0;


### PR DESCRIPTION
Based on https://matklad.github.io/2021/07/09/inline-in-rust.html.