### PR TITLE
More high-level public API for `ReplicationRules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0] - 2023-09-25
 
+- Add high-level API to extract replicated entities into `DynamicScene`.
 - Hide `ReplicationRules` low-level IDs API.
 - Move logic related to replication rules to `replicon_core::replication_rules` module.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.0] - 2023-09-25
 
+- Hide `ReplicationRules` low-level IDs API.
 - Move logic related to replication rules to `replicon_core::replication_rules` module.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.0] - 2023-09-25
 
 - Add high-level API to extract replicated entities into `DynamicScene`.
-- Hide `ReplicationRules` low-level IDs API.
+- Hide `ReplicationRules` from public API.
 - Move logic related to replication rules to `replicon_core::replication_rules` module.
 
 ### Changed

--- a/src/client.rs
+++ b/src/client.rs
@@ -137,7 +137,8 @@ fn deserialize_component_diffs(
         let components_count: u8 = bincode::deserialize_from(&mut *cursor)?;
         for _ in 0..components_count {
             let replication_id = DefaultOptions::new().deserialize_from(&mut *cursor)?;
-            let replication_info = replication_rules.get_info(replication_id);
+            // SAFETY: server and client have identical `ReplicationRules` and server always sends valid IDs.
+            let replication_info = unsafe { replication_rules.get_info_unchecked(replication_id) };
             match diff_kind {
                 DiffKind::Change => {
                     (replication_info.deserialize)(&mut entity, entity_map, cursor)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ struct Player;
 ```
 
 This pairs nicely with server state serialization and keeps saves clean.
-You can use [`replicate_into_scene`](replicon_core::replication_rules::replicate_into_scene)
+You can use [`replicate_into_scene`](replicon_core::replication_rules::replicate_into_scene) to
 fill `DynamicScene` with replicated entities and their components.
 
 ### Component relations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,6 @@ pub mod prelude {
         replicon_core::{
             replication_rules::{
                 AppReplicationExt, Ignored, MapNetworkEntities, Mapper, Replication,
-                ReplicationRules,
             },
             NetworkChannels, NetworkTick, RepliconCorePlugin,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ The idea was borrowed from [iyes_scene_tools](https://github.com/IyesGames/iyes_
 You don't want to replicate all components because not all of them are
 necessary to send over the network. Components that computed based on other
 components (like `GlobalTransform`) can be inserted after replication.
-This is easily done using a system with an `Added` query filter.
+This can be easily done using a system with an `Added` query filter.
 This way, you detect when such entities are spawned into the world, and you can
 do any additional setup on them using code. For example, if you have a
 character with mesh, you can replicate only your `Player` component and insert
@@ -178,9 +178,8 @@ struct Player;
 # fn deserialize_transform(_: &mut EntityMut, _: &mut NetworkEntityMap, _: &mut Cursor<Bytes>) -> Result<(), bincode::Error> { unimplemented!() }
 ```
 
-If your game have save states you probably want to re-use the same logic to
-keep you saves clean. Also, although things like `Handle<T>` can technically be
-serialized, they won't be valid after deserialization.
+This pairs nicely with server state serialization and keeps saves clean.
+You can use [`ReplicationRules`] to extract replicated entities into `DynamicScene`.
 
 ### Component relations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,8 @@ struct Player;
 ```
 
 This pairs nicely with server state serialization and keeps saves clean.
-You can use [`ReplicationRules`] to extract replicated entities into `DynamicScene`.
+You can use [`replicate_into_scene`](replicon_core::replication_rules::replicate_into_scene)
+fill `DynamicScene` with replicated entities and their components.
 
 ### Component relations
 

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -103,7 +103,7 @@ impl ReplicationRules {
         &self.ids
     }
 
-    /// Returns replication ID and meta information about component if its replicated.
+    /// Returns replication ID and meta information about the component if it's replicated.
     pub(crate) fn get(
         &self,
         component_id: ComponentId,

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -81,7 +81,7 @@ impl AppReplicationExt for App {
 ///
 /// See also [`replicate_into_scene`].
 #[derive(Resource)]
-pub struct ReplicationRules {
+pub(crate) struct ReplicationRules {
     /// Maps component IDs to their replication IDs.
     ids: HashMap<ComponentId, ReplicationId>,
 
@@ -242,12 +242,10 @@ fn remove_component<C: Component>(entity: &mut EntityMut) {
 ///
 /// Panics if any replicated component is not registered using `register_type()`
 /// or missing `#[reflect(Component)]`.
-pub fn replicate_into_scene(
-    scene: &mut DynamicScene,
-    world: &World,
-    registry: &AppTypeRegistry,
-    replication_rules: &ReplicationRules,
-) {
+pub fn replicate_into_scene(scene: &mut DynamicScene, world: &World) {
+    let registry = world.resource::<AppTypeRegistry>();
+    let replication_rules = world.resource::<ReplicationRules>();
+
     let registry = registry.read();
     for archetype in world
         .archetypes()
@@ -322,10 +320,8 @@ mod tests {
             ))
             .id();
 
-        let registry = app.world.resource::<AppTypeRegistry>();
-        let replication_rules = app.world.resource::<ReplicationRules>();
         let mut scene = DynamicScene::default();
-        replicate_into_scene(&mut scene, &app.world, registry, replication_rules);
+        replicate_into_scene(&mut scene, &app.world);
 
         assert!(scene.resources.is_empty());
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -229,10 +229,10 @@ fn collect_changes(
             }
 
             for component_id in archetype.components() {
-                let Some(&replication_id) = replication_rules.get_ids().get(&component_id) else {
+                let Some((replication_id, replication_info)) = replication_rules.get(component_id)
+                else {
                     continue;
                 };
-                let replication_info = replication_rules.get_info(replication_id);
                 if archetype.contains(replication_info.ignored_id) {
                     continue;
                 }

--- a/src/server/removal_tracker.rs
+++ b/src/server/removal_tracker.rs
@@ -119,7 +119,7 @@ mod tests {
 
         let component_id = app.world.init_component::<DummyComponent>();
         let replcation_rules = app.world.resource::<ReplicationRules>();
-        let replication_id = *replcation_rules.get_ids().get(&component_id).unwrap();
+        let (replication_id, _) = replcation_rules.get(component_id).unwrap();
         let removal_tracker = app.world.get::<RemovalTracker>(replicated_entity).unwrap();
         assert!(removal_tracker.contains_key(&replication_id));
     }


### PR DESCRIPTION
- Make current API more safe and explicit and hide it.
- Introduce a high-level API to build `DynamicScene`.

I will be happy to re-export low-level API again if anyone will need it, but I used it only to serialize server state and decided that it makes sense to move this part of my game into a library too.