### PR TITLE
Remove derive-more dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,6 @@ bevy = { version = "0.11", default-features = false, features = ["bevy_scene"] }
 bincode = "1.3"
 serde = "1.0"
 strum = { version = "0.25", features = ["derive"] }
-derive_more = { version = "0.99", default-features = false, features = [
-  "constructor",
-] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -21,7 +21,6 @@ use bevy_renet::{
     RenetServerPlugin,
 };
 use bincode::{DefaultOptions, Options};
-use derive_more::Constructor;
 
 use crate::replicon_core::{
     replication_rules::{ReplicationId, ReplicationInfo, ReplicationRules},
@@ -32,7 +31,6 @@ use removal_tracker::{RemovalTracker, RemovalTrackerPlugin};
 
 pub const SERVER_ID: u64 = 0;
 
-#[derive(Constructor)]
 pub struct ServerPlugin {
     tick_policy: TickPolicy,
 }
@@ -87,6 +85,10 @@ impl Plugin for ServerPlugin {
 }
 
 impl ServerPlugin {
+    pub fn new(tick_policy: TickPolicy) -> Self {
+        Self { tick_policy }
+    }
+
     fn acks_receiving_system(
         mut server_ticks: ResMut<ServerTicks>,
         mut server: ResMut<RenetServer>,


### PR DESCRIPTION
I used it long time ago when I had reflection to reduce the boilerplate.
I think we should remove it now.