### PR TITLE
Move ReplicationBuffer to separate module

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
 pub(super) mod despawn_tracker;
 pub(super) mod removal_tracker;
+pub(super) mod replication_buffer;
 
-use std::{io::Cursor, mem, time::Duration};
+use std::time::Duration;
 
 use bevy::{
     ecs::{
@@ -10,26 +11,22 @@ use bevy::{
         system::SystemChangeTick,
     },
     prelude::*,
-    ptr::Ptr,
     scene::DynamicEntity,
     time::common_conditions::on_timer,
     utils::HashMap,
 };
 use bevy_renet::{
-    renet::{Bytes, RenetClient, RenetServer, ServerEvent},
+    renet::{RenetClient, RenetServer, ServerEvent},
     transport::NetcodeServerPlugin,
     RenetServerPlugin,
 };
-use bincode::{DefaultOptions, Options};
 
 use crate::replicon_core::{
-    replication_rules::{ReplicationId, ReplicationInfo, ReplicationRules},
-    replicon_tick::RepliconTick,
-    REPLICATION_CHANNEL_ID,
+    replication_rules::ReplicationRules, replicon_tick::RepliconTick, REPLICATION_CHANNEL_ID,
 };
 use despawn_tracker::{DespawnTracker, DespawnTrackerPlugin};
 use removal_tracker::{RemovalTracker, RemovalTrackerPlugin};
-use varint_rs::VarintWriter;
+use replication_buffer::ReplicationBuffer;
 
 pub const SERVER_ID: u64 = 0;
 
@@ -170,18 +167,7 @@ impl ServerPlugin {
         collect_despawns(buffers, &despawn_tracker, change_tick.this_run())?;
 
         for buffer in buffers {
-            debug_assert_eq!(buffer.array_len, 0);
-            debug_assert_eq!(buffer.entity_data_len, 0);
-
-            if buffer.arrays_with_data > 0 {
-                buffer.trim_empty_arrays();
-
-                set.p1().send_message(
-                    buffer.client_id,
-                    REPLICATION_CHANNEL_ID,
-                    Bytes::copy_from_slice(buffer.message.get_ref()),
-                );
-            }
+            buffer.send_to(&mut set.p1(), REPLICATION_CHANNEL_ID);
         }
 
         Ok(())
@@ -278,7 +264,7 @@ fn collect_changes(
                             unsafe { column.get_data_unchecked(archetype_entity.table_row()) };
 
                         for buffer in &mut *buffers {
-                            if ticks.is_changed(buffer.system_tick, system_tick) {
+                            if ticks.is_changed(buffer.system_tick(), system_tick) {
                                 buffer.write_change(replication_info, replication_id, component)?;
                             }
                         }
@@ -299,7 +285,7 @@ fn collect_changes(
                             .unwrap_or_else(|| panic!("{entity:?} should have {component_id:?}"));
 
                         for buffer in &mut *buffers {
-                            if ticks.is_changed(buffer.system_tick, system_tick) {
+                            if ticks.is_changed(buffer.system_tick(), system_tick) {
                                 buffer.write_change(replication_info, replication_id, component)?;
                             }
                         }
@@ -334,7 +320,7 @@ fn collect_removals(
         for buffer in &mut *buffers {
             buffer.start_entity_data(entity);
             for (&replication_id, &tick) in &removal_tracker.0 {
-                if tick.is_newer_than(buffer.system_tick, system_tick) {
+                if tick.is_newer_than(buffer.system_tick(), system_tick) {
                     buffer.write_removal(replication_id)?;
                 }
             }
@@ -361,7 +347,7 @@ fn collect_despawns(
 
     for &(entity, tick) in &despawn_tracker.despawns {
         for buffer in &mut *buffers {
-            if tick.is_newer_than(buffer.system_tick, system_tick) {
+            if tick.is_newer_than(buffer.system_tick(), system_tick) {
                 buffer.write_despawn(entity)?;
             }
         }
@@ -438,253 +424,6 @@ impl AckedTicks {
     #[inline]
     pub fn acked_ticks(&self) -> &HashMap<u64, RepliconTick> {
         &self.clients
-    }
-}
-
-/// A reusable buffer with replicated data for a client.
-///
-/// See also [Limits](../index.html#limits)
-struct ReplicationBuffer {
-    /// ID of a client for which this buffer is written.
-    client_id: u64,
-
-    /// Last system tick acknowledged by the client.
-    ///
-    /// Used for changes preparation.
-    system_tick: Tick,
-
-    /// Buffer with serialized data.
-    message: Cursor<Vec<u8>>,
-
-    /// Position of the array from last call of [`Self::start_array`].
-    array_pos: u64,
-
-    /// Length of the array that updated automatically after writing data.
-    array_len: u16,
-
-    /// The number of non-empty arrays stored.
-    arrays_with_data: usize,
-
-    /// The number of empty arrays at the end. Can be removed using [`Self::trim_empty_arrays`]
-    trailing_empty_arrays: usize,
-
-    /// Position of entity after [`Self::start_entity_data`] or its data after [`Self::write_data_entity`].
-    entity_data_pos: u64,
-
-    /// Length of the data for entity that updated automatically after writing data.
-    entity_data_len: u8,
-
-    /// Entity from last call of [`Self::start_entity_data`].
-    data_entity: Entity,
-}
-
-impl ReplicationBuffer {
-    /// Creates a new buffer with assigned client ID and acknowledged system tick
-    /// and writes current server tick into buffer data.
-    fn new(
-        client_id: u64,
-        system_tick: Tick,
-        replicon_tick: RepliconTick,
-    ) -> Result<Self, bincode::Error> {
-        let mut message = Default::default();
-        bincode::serialize_into(&mut message, &replicon_tick)?;
-        Ok(Self {
-            client_id,
-            system_tick,
-            message,
-            array_pos: Default::default(),
-            array_len: Default::default(),
-            arrays_with_data: Default::default(),
-            trailing_empty_arrays: Default::default(),
-            entity_data_pos: Default::default(),
-            entity_data_len: Default::default(),
-            data_entity: Entity::PLACEHOLDER,
-        })
-    }
-
-    /// Reassigns current client ID and acknowledged system tick to the buffer
-    /// and replaces buffer data with current server tick.
-    ///
-    /// Keeps allocated capacity of the buffer data.
-    fn reset(
-        &mut self,
-        client_id: u64,
-        system_tick: Tick,
-        replicon_tick: RepliconTick,
-    ) -> Result<(), bincode::Error> {
-        self.client_id = client_id;
-        self.system_tick = system_tick;
-        self.message.set_position(0);
-        self.message.get_mut().clear();
-        self.arrays_with_data = 0;
-        bincode::serialize_into(&mut self.message, &replicon_tick)?;
-
-        Ok(())
-    }
-
-    /// Starts writing array by remembering its position to write length after.
-    ///
-    /// Arrays can contain entity data or despawns inside.
-    /// Length will be increased automatically after writing data.
-    /// See also [`Self::end_array`], [`Self::start_entity_data`] and [`Self::write_despawn`].
-    fn start_array(&mut self) {
-        debug_assert_eq!(self.array_len, 0);
-
-        self.array_pos = self.message.position();
-        self.message
-            .set_position(self.array_pos + mem::size_of_val(&self.array_len) as u64);
-    }
-
-    /// Ends writing array by writing its length into the last remembered position.
-    ///
-    /// See also [`Self::start_array`].
-    fn end_array(&mut self) -> Result<(), bincode::Error> {
-        if self.array_len != 0 {
-            let previous_pos = self.message.position();
-            self.message.set_position(self.array_pos);
-
-            bincode::serialize_into(&mut self.message, &self.array_len)?;
-
-            self.message.set_position(previous_pos);
-            self.array_len = 0;
-            self.arrays_with_data += 1;
-            self.trailing_empty_arrays = 0;
-        } else {
-            self.trailing_empty_arrays += 1;
-            self.message.set_position(self.array_pos);
-            bincode::serialize_into(&mut self.message, &self.array_len)?;
-        }
-
-        Ok(())
-    }
-
-    /// Crops empty arrays at the end.
-    ///
-    /// Should only be called after all arrays have been written, because
-    /// removed array somewhere the middle cannot be detected during deserialization.
-    fn trim_empty_arrays(&mut self) {
-        let used_len = self.message.get_ref().len()
-            - self.trailing_empty_arrays * mem::size_of_val(&self.array_len);
-        self.message.get_mut().truncate(used_len);
-        self.trailing_empty_arrays = 0;
-    }
-
-    /// Starts writing entity and its data by remembering `entity`.
-    ///
-    /// Arrays can contain component changes or removals inside.
-    /// Length will be increased automatically after writing data.
-    /// Entity will be written lazily after first data write and its position will be remembered to write length later.
-    /// See also [`Self::end_entity_data`], [`Self::write_current_entity`], [`Self::write_change`] and [`Self::write_removal`].
-    fn start_entity_data(&mut self, entity: Entity) {
-        debug_assert_eq!(self.entity_data_len, 0);
-
-        self.data_entity = entity;
-    }
-
-    /// Writes entity for current data and updates remembered position for it to write length later.
-    ///
-    /// Should be called only after first data write.
-    fn write_data_entity(&mut self) -> Result<(), bincode::Error> {
-        self.write_entity(self.data_entity)?;
-        self.entity_data_pos = self.message.position();
-        self.message
-            .set_position(self.entity_data_pos + mem::size_of_val(&self.entity_data_len) as u64);
-
-        Ok(())
-    }
-
-    /// Ends writing entity data by writing its length into the last remembered position.
-    ///
-    /// If the entity data is empty, nothing will be written.
-    /// See also [`Self::start_array`], [`Self::write_current_entity`], [`Self::write_change`] and [`Self::write_removal`].
-    fn end_entity_data(&mut self) -> Result<(), bincode::Error> {
-        if self.entity_data_len != 0 {
-            let previous_pos = self.message.position();
-            self.message.set_position(self.entity_data_pos);
-
-            bincode::serialize_into(&mut self.message, &self.entity_data_len)?;
-
-            self.message.set_position(previous_pos);
-            self.entity_data_len = 0;
-            self.array_len = self
-                .array_len
-                .checked_add(1)
-                .ok_or(bincode::ErrorKind::SizeLimit)?;
-        } else {
-            self.message.set_position(self.entity_data_pos);
-        }
-
-        Ok(())
-    }
-
-    /// Serializes `replication_id` and component from `ptr` into the buffer data.
-    ///
-    /// Should be called only inside entity data.
-    /// Increases entity data length by 1.
-    /// See also [`Self::start_entity_data`].
-    fn write_change(
-        &mut self,
-        replication_info: &ReplicationInfo,
-        replication_id: ReplicationId,
-        ptr: Ptr,
-    ) -> Result<(), bincode::Error> {
-        if self.entity_data_len == 0 {
-            self.write_data_entity()?;
-        }
-
-        DefaultOptions::new().serialize_into(&mut self.message, &replication_id)?;
-        (replication_info.serialize)(ptr, &mut self.message)?;
-        self.entity_data_len += 1;
-
-        Ok(())
-    }
-
-    /// Serializes `replication_id` of the removed component into the buffer data.
-    ///
-    /// Should be called only inside entity data.
-    /// Increases entity data length by 1.
-    /// See also [`Self::start_entity_data`].
-    fn write_removal(&mut self, replication_id: ReplicationId) -> Result<(), bincode::Error> {
-        if self.entity_data_len == 0 {
-            self.write_data_entity()?;
-        }
-
-        DefaultOptions::new().serialize_into(&mut self.message, &replication_id)?;
-        self.entity_data_len += 1;
-
-        Ok(())
-    }
-
-    /// Serializes despawned `entity`.
-    ///
-    /// Should be called only inside array.
-    /// Increases array length by 1.
-    /// See also [`Self::start_array`].
-    fn write_despawn(&mut self, entity: Entity) -> Result<(), bincode::Error> {
-        self.write_entity(entity)?;
-        self.array_len = self
-            .array_len
-            .checked_add(1)
-            .ok_or(bincode::ErrorKind::SizeLimit)?;
-
-        Ok(())
-    }
-
-    /// Serializes `entity` by writing its index and generation as separate varints.
-    ///
-    /// The index is first prepended with a bit flag to indicate if the generation
-    /// is serialized or not (it is not serialized if equal to zero).
-    fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
-        let mut flagged_index = (entity.index() as u64) << 1;
-        let flag = entity.generation() > 0;
-        flagged_index |= flag as u64;
-
-        self.message.write_u64_varint(flagged_index)?;
-        if flag {
-            self.message.write_u32_varint(entity.generation())?;
-        }
-
-        Ok(())
     }
 }
 

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -1,15 +1,14 @@
 use std::{io::Cursor, mem};
 
 use bevy::{ecs::component::Tick, prelude::*, ptr::Ptr};
-use bincode::{DefaultOptions, Options};
-
 use bevy_renet::renet::{Bytes, RenetServer};
+use bincode::{DefaultOptions, Options};
+use varint_rs::VarintWriter;
 
 use crate::replicon_core::{
     replication_rules::{ReplicationId, ReplicationInfo},
     replicon_tick::RepliconTick,
 };
-use varint_rs::VarintWriter;
 
 /// A reusable buffer with replicated data for a client.
 ///

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -49,11 +49,6 @@ pub(super) struct ReplicationBuffer {
 }
 
 impl ReplicationBuffer {
-    /// Read access to the buffer's system tick (this client's last acked replicon tick).
-    pub(super) fn system_tick(&self) -> Tick {
-        self.system_tick
-    }
-
     /// Creates a new buffer with assigned client ID and acknowledged system tick
     /// and writes current server tick into buffer data.
     pub(super) fn new(
@@ -75,6 +70,11 @@ impl ReplicationBuffer {
             entity_data_len: Default::default(),
             data_entity: Entity::PLACEHOLDER,
         })
+    }
+
+    /// Read access to the buffer's system tick (this client's last acked replicon tick).
+    pub(super) fn system_tick(&self) -> Tick {
+        self.system_tick
     }
 
     /// Reassigns current client ID and acknowledged system tick to the buffer

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -1,0 +1,285 @@
+use std::{io::Cursor, mem};
+
+use bevy::{ecs::component::Tick, prelude::*, ptr::Ptr};
+use bincode::{DefaultOptions, Options};
+
+use bevy_renet::renet::{Bytes, RenetServer};
+
+use crate::replicon_core::{
+    replication_rules::{ReplicationId, ReplicationInfo},
+    replicon_tick::RepliconTick,
+};
+use varint_rs::VarintWriter;
+
+/// A reusable buffer with replicated data for a client.
+///
+/// See also [Limits](../index.html#limits)
+pub(super) struct ReplicationBuffer {
+    /// ID of a client for which this buffer is written.
+    client_id: u64,
+
+    /// Last system tick acknowledged by the client.
+    ///
+    /// Used for changes preparation.
+    system_tick: Tick,
+
+    /// Buffer with serialized data.
+    message: Cursor<Vec<u8>>,
+
+    /// Position of the array from last call of [`Self::start_array`].
+    array_pos: u64,
+
+    /// Length of the array that updated automatically after writing data.
+    array_len: u16,
+
+    /// The number of non-empty arrays stored.
+    arrays_with_data: usize,
+
+    /// The number of empty arrays at the end. Can be removed using [`Self::trim_empty_arrays`]
+    trailing_empty_arrays: usize,
+
+    /// Position of entity after [`Self::start_entity_data`] or its data after [`Self::write_data_entity`].
+    entity_data_pos: u64,
+
+    /// Length of the data for entity that updated automatically after writing data.
+    entity_data_len: u8,
+
+    /// Entity from last call of [`Self::start_entity_data`].
+    data_entity: Entity,
+}
+
+impl ReplicationBuffer {
+    /// Read access to the buffer's system tick (this client's last acked replicon tick).
+    pub(super) fn system_tick(&self) -> Tick {
+        self.system_tick
+    }
+
+    /// Creates a new buffer with assigned client ID and acknowledged system tick
+    /// and writes current server tick into buffer data.
+    pub(super) fn new(
+        client_id: u64,
+        system_tick: Tick,
+        replicon_tick: RepliconTick,
+    ) -> Result<Self, bincode::Error> {
+        let mut message = Default::default();
+        bincode::serialize_into(&mut message, &replicon_tick)?;
+        Ok(Self {
+            client_id,
+            system_tick,
+            message,
+            array_pos: Default::default(),
+            array_len: Default::default(),
+            arrays_with_data: Default::default(),
+            trailing_empty_arrays: Default::default(),
+            entity_data_pos: Default::default(),
+            entity_data_len: Default::default(),
+            data_entity: Entity::PLACEHOLDER,
+        })
+    }
+
+    /// Reassigns current client ID and acknowledged system tick to the buffer
+    /// and replaces buffer data with current server tick.
+    ///
+    /// Keeps allocated capacity of the buffer data.
+    pub(super) fn reset(
+        &mut self,
+        client_id: u64,
+        system_tick: Tick,
+        replicon_tick: RepliconTick,
+    ) -> Result<(), bincode::Error> {
+        self.client_id = client_id;
+        self.system_tick = system_tick;
+        self.message.set_position(0);
+        self.message.get_mut().clear();
+        self.arrays_with_data = 0;
+        bincode::serialize_into(&mut self.message, &replicon_tick)?;
+
+        Ok(())
+    }
+
+    /// Starts writing array by remembering its position to write length after.
+    ///
+    /// Arrays can contain entity data or despawns inside.
+    /// Length will be increased automatically after writing data.
+    /// See also [`Self::end_array`], [`Self::start_entity_data`] and [`Self::write_despawn`].
+    pub(super) fn start_array(&mut self) {
+        debug_assert_eq!(self.array_len, 0);
+
+        self.array_pos = self.message.position();
+        self.message
+            .set_position(self.array_pos + mem::size_of_val(&self.array_len) as u64);
+    }
+
+    /// Ends writing array by writing its length into the last remembered position.
+    ///
+    /// See also [`Self::start_array`].
+    pub(super) fn end_array(&mut self) -> Result<(), bincode::Error> {
+        if self.array_len != 0 {
+            let previous_pos = self.message.position();
+            self.message.set_position(self.array_pos);
+
+            bincode::serialize_into(&mut self.message, &self.array_len)?;
+
+            self.message.set_position(previous_pos);
+            self.array_len = 0;
+            self.arrays_with_data += 1;
+            self.trailing_empty_arrays = 0;
+        } else {
+            self.trailing_empty_arrays += 1;
+            self.message.set_position(self.array_pos);
+            bincode::serialize_into(&mut self.message, &self.array_len)?;
+        }
+
+        Ok(())
+    }
+
+    /// Crops empty arrays at the end.
+    ///
+    /// Should only be called after all arrays have been written, because
+    /// removed array somewhere the middle cannot be detected during deserialization.
+    pub(super) fn trim_empty_arrays(&mut self) {
+        let used_len = self.message.get_ref().len()
+            - self.trailing_empty_arrays * mem::size_of_val(&self.array_len);
+        self.message.get_mut().truncate(used_len);
+        self.trailing_empty_arrays = 0;
+    }
+
+    /// Starts writing entity and its data by remembering `entity`.
+    ///
+    /// Arrays can contain component changes or removals inside.
+    /// Length will be increased automatically after writing data.
+    /// Entity will be written lazily after first data write and its position will be remembered to write length later.
+    /// See also [`Self::end_entity_data`], [`Self::write_current_entity`], [`Self::write_change`]
+    /// and [`Self::write_removal`].
+    pub(super) fn start_entity_data(&mut self, entity: Entity) {
+        debug_assert_eq!(self.entity_data_len, 0);
+
+        self.data_entity = entity;
+    }
+
+    /// Writes entity for current data and updates remembered position for it to write length later.
+    ///
+    /// Should be called only after first data write.
+    pub(super) fn write_data_entity(&mut self) -> Result<(), bincode::Error> {
+        self.write_entity(self.data_entity)?;
+        self.entity_data_pos = self.message.position();
+        self.message
+            .set_position(self.entity_data_pos + mem::size_of_val(&self.entity_data_len) as u64);
+
+        Ok(())
+    }
+
+    /// Ends writing entity data by writing its length into the last remembered position.
+    ///
+    /// If the entity data is empty, nothing will be written.
+    /// See also [`Self::start_array`], [`Self::write_current_entity`], [`Self::write_change`] and
+    /// [`Self::write_removal`].
+    pub(super) fn end_entity_data(&mut self) -> Result<(), bincode::Error> {
+        if self.entity_data_len != 0 {
+            let previous_pos = self.message.position();
+            self.message.set_position(self.entity_data_pos);
+
+            bincode::serialize_into(&mut self.message, &self.entity_data_len)?;
+
+            self.message.set_position(previous_pos);
+            self.entity_data_len = 0;
+            self.array_len = self
+                .array_len
+                .checked_add(1)
+                .ok_or(bincode::ErrorKind::SizeLimit)?;
+        } else {
+            self.message.set_position(self.entity_data_pos);
+        }
+
+        Ok(())
+    }
+
+    /// Serializes `replication_id` and component from `ptr` into the buffer data.
+    ///
+    /// Should be called only inside entity data.
+    /// Increases entity data length by 1.
+    /// See also [`Self::start_entity_data`].
+    pub(super) fn write_change(
+        &mut self,
+        replication_info: &ReplicationInfo,
+        replication_id: ReplicationId,
+        ptr: Ptr,
+    ) -> Result<(), bincode::Error> {
+        if self.entity_data_len == 0 {
+            self.write_data_entity()?;
+        }
+
+        DefaultOptions::new().serialize_into(&mut self.message, &replication_id)?;
+        (replication_info.serialize)(ptr, &mut self.message)?;
+        self.entity_data_len += 1;
+
+        Ok(())
+    }
+
+    /// Serializes `replication_id` of the removed component into the buffer data.
+    ///
+    /// Should be called only inside entity data.
+    /// Increases entity data length by 1.
+    /// See also [`Self::start_entity_data`].
+    pub(super) fn write_removal(
+        &mut self,
+        replication_id: ReplicationId,
+    ) -> Result<(), bincode::Error> {
+        if self.entity_data_len == 0 {
+            self.write_data_entity()?;
+        }
+
+        DefaultOptions::new().serialize_into(&mut self.message, &replication_id)?;
+        self.entity_data_len += 1;
+
+        Ok(())
+    }
+
+    /// Serializes despawned `entity`.
+    ///
+    /// Should be called only inside array.
+    /// Increases array length by 1.
+    /// See also [`Self::start_array`].
+    pub(super) fn write_despawn(&mut self, entity: Entity) -> Result<(), bincode::Error> {
+        self.write_entity(entity)?;
+        self.array_len = self
+            .array_len
+            .checked_add(1)
+            .ok_or(bincode::ErrorKind::SizeLimit)?;
+
+        Ok(())
+    }
+
+    /// Serializes `entity` by writing its index and generation as separate varints.
+    ///
+    /// The index is first prepended with a bit flag to indicate if the generation
+    /// is serialized or not (it is not serialized if equal to zero).
+    pub(super) fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
+        let mut flagged_index = (entity.index() as u64) << 1;
+        let flag = entity.generation() > 0;
+        flagged_index |= flag as u64;
+
+        self.message.write_u64_varint(flagged_index)?;
+        if flag {
+            self.message.write_u32_varint(entity.generation())?;
+        }
+
+        Ok(())
+    }
+
+    /// Send the buffer contents into a renet server channel.
+    pub(super) fn send_to(&mut self, server: &mut RenetServer, replication_channel_id: u8) {
+        debug_assert_eq!(self.array_len, 0);
+        debug_assert_eq!(self.entity_data_len, 0);
+
+        if self.arrays_with_data > 0 {
+            self.trim_empty_arrays();
+
+            server.send_message(
+                self.client_id,
+                replication_channel_id,
+                Bytes::copy_from_slice(self.message.get_ref()),
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Problem

The `server.rs` file is overloaded with different things.

### Solution

Move `ReplicationBuffer` to a separate module.