### PR TITLE
Warn when deserializing a mapping that already exists

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -154,7 +154,12 @@ fn deserialize_entity_mappings(
         let client_entity = deserialize_entity(cursor)?;
 
         if let Some(entry) = entity_map.to_client().get(&server_entity) {
-            panic!("received mapping from {server_entity:?} to {client_entity:?}, but already mapped to {entry:?}");
+            if *entry == client_entity {
+                warn!("ignoring mapping from {server_entity:?} to {client_entity:?} that already exists");
+                continue;
+            } else {
+                panic!("received mapping from {server_entity:?} to {client_entity:?}, but already mapped to {entry:?}");
+            }
         }
 
         if let Some(mut entity) = world.get_entity_mut(client_entity) {


### PR DESCRIPTION
It is best not to panic for non-critical errors.