### PR TITLE
Serde minor refactor

### DIFF
--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -269,7 +269,7 @@ impl ReplicationBuffer {
     ///
     /// The index is first prepended with a bit flag to indicate if the generation
     /// is serialized or not (it is not serialized if equal to zero).
-    pub(super) fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
+    fn write_entity(&mut self, entity: Entity) -> Result<(), bincode::Error> {
         let mut flagged_index = (entity.index() as u64) << 1;
         let flag = entity.generation() > 0;
         flagged_index |= flag as u64;


### PR DESCRIPTION
Initially I thought about providing a mirroring API for `ReplicationBuffer`, something like `read_array_len`, `read_entity_data_len`, `read_change`, but it started to look even worse. So I decided to keep everything as is for now.
But I'm keeping some minor changes that improve the readability of the current solution: renaming, documentation, and completely hiding `write_entity` (shouldn't and isn't used externally).