### PR TITLE
Add "Simple box" example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bevy = { version = "0.11", default-features = false, features = [
   "bevy_sprite",
   "bevy_text",
   "bevy_ui",
+  "bevy_gizmos",
   "x11",
   "default_font",
 ] }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Write the same logic that works for both multiplayer and single-player. The crat
 
 Check out the [quick start guide](https://docs.rs/bevy_replicon/latest/bevy_replicon).
 
-See also [Tic-Tac-Toe](https://github.com/lifescapegame/bevy_replicon/tree/master/examples/tic_tac_toe.rs) example.
-
+See also [examples](https://github.com/lifescapegame/bevy_replicon/tree/master/examples).
 
 ## Bevy compatibility
 

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -214,7 +214,7 @@ fn cli_system(
             let public_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
             let socket = UdpSocket::bind(public_addr)?;
             let server_config = ServerConfig {
-                max_clients: 4,
+                max_clients: 10,
                 protocol_id: PROTOCOL_ID,
                 public_addr,
                 authentication: ServerAuthentication::Unsecure,

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -30,25 +30,33 @@ fn main() {
                 .build()
                 .set(ServerPlugin::new(TickPolicy::MaxTickRate(60)))),
         )
-        .replicate::<PlayerPosition>()
-        .replicate::<PlayerColor>()
-        .add_client_event::<MoveCommandEvent>(SendPolicy::Ordered)
-        .add_systems(
-            Startup,
-            (cli_system.pipe(system_adapter::unwrap), init_system),
-        )
-        // Systems that run only on the server or a single player instance
-        .add_systems(Update, (movement_system).run_if(has_authority()))
-        // Systems that run only on the server
-        .add_systems(
-            Update,
-            (server_event_system).run_if(resource_exists::<RenetServer>()),
-        )
-        // Systems that run only on the client or a single player instance
-        .add_systems(Update, (input_system).run_if(is_client_or_single_player()))
-        // Systems that run everywhere
-        .add_systems(Update, draw_box_system)
+        .add_plugins(MoveABoxPlugin)
         .run();
+}
+
+struct MoveABoxPlugin;
+
+impl Plugin for MoveABoxPlugin {
+    fn build(&self, app: &mut App) {
+        app.replicate::<PlayerPosition>()
+            .replicate::<PlayerColor>()
+            .add_client_event::<MoveCommandEvent>(SendPolicy::Ordered)
+            .add_systems(
+                Startup,
+                (cli_system.pipe(system_adapter::unwrap), init_system),
+            )
+            // Systems that run only on the server or a single player instance
+            .add_systems(Update, (movement_system).run_if(has_authority()))
+            // Systems that run only on the server
+            .add_systems(
+                Update,
+                (server_event_system).run_if(resource_exists::<RenetServer>()),
+            )
+            // Systems that run only on the client or a single player instance
+            .add_systems(Update, (input_system).run_if(is_client_or_single_player()))
+            // Systems that run everywhere
+            .add_systems(Update, draw_box_system);
+    }
 }
 
 #[derive(Component, Deserialize, Serialize)]

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -47,7 +47,7 @@ fn main() {
         // Systems that run only on the client or a single player instance
         .add_systems(Update, (input_system).run_if(is_client_or_single_player()))
         // Systems that run everywhere
-        .add_systems(Update, (draw_box_system))
+        .add_systems(Update, draw_box_system)
         .run();
 }
 

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -31,9 +31,9 @@ fn main() {
             ..Default::default()
         }))
         .add_plugins(
-            (ReplicationPlugins
+            ReplicationPlugins
                 .build()
-                .set(ServerPlugin::new(TickPolicy::MaxTickRate(60)))),
+                .set(ServerPlugin::new(TickPolicy::MaxTickRate(60))),
         )
         .add_plugins(MoveABoxPlugin)
         .run();

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -1,18 +1,23 @@
-use std::error::Error;
-use std::net::Ipv4Addr;
-use std::net::{IpAddr, SocketAddr, UdpSocket};
-use std::time::SystemTime;
+use std::{
+    error::Error,
+    net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
+    time::SystemTime,
+};
 
 use bevy::prelude::*;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use bevy_replicon::prelude::*;
-use bevy_replicon::renet::transport::{
-    ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport, ServerAuthentication,
-    ServerConfig,
+use bevy_replicon::{
+    prelude::*,
+    renet::{
+        transport::{
+            ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport,
+            ServerAuthentication, ServerConfig,
+        },
+        ConnectionConfig, ServerEvent,
+    },
 };
-use bevy_replicon::renet::{ConnectionConfig, ServerEvent};
 
 fn main() {
     App::new()

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -52,10 +52,8 @@ impl Plugin for MoveABoxPlugin {
                 Update,
                 (server_event_system).run_if(resource_exists::<RenetServer>()),
             )
-            // Systems that run only on the client or a single player instance
-            .add_systems(Update, (input_system).run_if(is_client_or_single_player()))
             // Systems that run everywhere
-            .add_systems(Update, draw_box_system);
+            .add_systems(Update, (draw_box_system, input_system));
     }
 }
 
@@ -240,6 +238,7 @@ fn cli_system(
                     ..default()
                 },
             ));
+            commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
         }
         Cli::Client { port, ip } => {
             let server_channels_config = network_channels.server_channels();
@@ -278,9 +277,4 @@ fn cli_system(
     }
 
     Ok(())
-}
-
-fn is_client_or_single_player(
-) -> impl FnMut(Option<Res<RenetClient>>, Option<Res<RenetServer>>) -> bool + Clone {
-    move |client, server| client.is_some() || server.is_none()
 }

--- a/examples/move_a_box.rs
+++ b/examples/move_a_box.rs
@@ -1,0 +1,263 @@
+use std::error::Error;
+use std::net::Ipv4Addr;
+use std::net::{IpAddr, SocketAddr, UdpSocket};
+use std::time::SystemTime;
+
+use bevy::prelude::*;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+use bevy_replicon::prelude::*;
+use bevy_replicon::renet::transport::{
+    ClientAuthentication, NetcodeClientTransport, NetcodeServerTransport, ServerAuthentication,
+    ServerConfig,
+};
+use bevy_replicon::renet::{ConnectionConfig, ServerEvent};
+
+fn main() {
+    App::new()
+        .init_resource::<Cli>() // Parse CLI before creating window.
+        .add_plugins(DefaultPlugins.build().set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Move a Box".into(),
+                resolution: (800.0, 600.0).into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .add_plugins(
+            (ReplicationPlugins
+                .build()
+                .set(ServerPlugin::new(TickPolicy::MaxTickRate(60)))),
+        )
+        .replicate::<PlayerPosition>()
+        .add_client_event::<MoveCommandEvent>(SendPolicy::Ordered)
+        .add_systems(
+            Startup,
+            (cli_system.pipe(system_adapter::unwrap), init_system),
+        )
+        // Systems that run only on the server or a single player instance
+        .add_systems(Update, (movement_system).run_if(has_authority()))
+        // Systems that run only on the server
+        .add_systems(
+            Update,
+            (server_event_system).run_if(resource_exists::<RenetServer>()),
+        )
+        // Systems that run only on the client or a single player instance
+        .add_systems(Update, (input_system).run_if(is_client_or_single_player()))
+        // Systems that run everywhere
+        .add_systems(Update, (draw_box_system))
+        .run();
+}
+
+#[derive(Component, Deserialize, Serialize)]
+struct PlayerPosition(Vec2);
+#[derive(Component, Serialize, Deserialize)]
+struct Player(u64);
+
+/// Contains player ID
+#[derive(Bundle)]
+struct PlayerBundle {
+    player: Player,
+    position: PlayerPosition,
+    replication: Replication,
+}
+
+impl PlayerBundle {
+    fn new(id: u64, position: Vec2) -> Self {
+        Self {
+            player: Player(id),
+            position: PlayerPosition(position),
+            replication: Replication,
+        }
+    }
+}
+
+fn init_system(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn draw_box_system(q_net_pos: Query<&PlayerPosition>, mut gizmos: Gizmos) {
+    for p in q_net_pos.iter() {
+        gizmos.rect(
+            Vec3::new(p.0.x, p.0.y, 0.),
+            Quat::IDENTITY,
+            Vec2::ONE * 50.,
+            Color::GREEN,
+        );
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Event, Serialize)]
+struct MoveCommandEvent {
+    pub direction: Vec2,
+}
+
+// Read player inputs and publish MoveCommandEvents, only for client or single player instance
+fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
+    let right = input.pressed(KeyCode::Right);
+    let left = input.pressed(KeyCode::Left);
+    let up = input.pressed(KeyCode::Up);
+    let down = input.pressed(KeyCode::Down);
+    let mut direction = Vec2::ZERO;
+    if right {
+        direction.x += 1.0;
+    }
+    if left {
+        direction.x -= 1.0;
+    }
+    if up {
+        direction.y += 1.0;
+    }
+    if down {
+        direction.y -= 1.0;
+    }
+    if right || left || up || down {
+        move_event.send(MoveCommandEvent {
+            direction: direction.normalize_or_zero(),
+        })
+    }
+}
+
+// Mutate PlayerPosition based on MoveCommandEvents, runs on server or single player instance
+fn movement_system(
+    mut events: EventReader<FromClient<MoveCommandEvent>>,
+    mut q_net_pos: Query<(&Player, &mut PlayerPosition)>,
+    time: Res<Time>,
+) {
+    let move_speed = 300.0;
+    for FromClient { client_id, event } in &mut events {
+        info!("received event {event:?} from client {client_id}");
+        for (player, mut position) in q_net_pos.iter_mut() {
+            if *client_id == player.0 {
+                position.0 += event.direction * time.delta_seconds() * move_speed;
+            }
+        }
+    }
+}
+
+// Spawns a new player whenever a client connects
+fn server_event_system(mut commands: Commands, mut server_event: EventReader<ServerEvent>) {
+    for event in &mut server_event {
+        match event {
+            ServerEvent::ClientConnected { client_id } => {
+                info!("Player: {client_id} Connected");
+                commands.spawn(PlayerBundle::new(*client_id, Vec2::ZERO));
+            }
+            ServerEvent::ClientDisconnected { client_id, reason } => {
+                info!("Client {client_id} disconnected: {reason}");
+            }
+        }
+    }
+}
+
+const PORT: u16 = 5000;
+const PROTOCOL_ID: u64 = 0;
+
+#[derive(Debug, Parser, PartialEq, Resource)]
+enum Cli {
+    SinglePlayer,
+    Server {
+        #[arg(short, long, default_value_t = PORT)]
+        port: u16,
+    },
+    Client {
+        #[arg(short, long, default_value_t = Ipv4Addr::LOCALHOST.into())]
+        ip: IpAddr,
+
+        #[arg(short, long, default_value_t = PORT)]
+        port: u16,
+    },
+}
+
+impl Default for Cli {
+    fn default() -> Self {
+        Self::parse()
+    }
+}
+
+fn cli_system(
+    mut commands: Commands,
+    cli: Res<Cli>,
+    network_channels: Res<NetworkChannels>,
+) -> Result<(), Box<dyn Error>> {
+    match *cli {
+        Cli::SinglePlayer => {
+            commands.spawn(PlayerBundle::new(0, Vec2::ZERO));
+        }
+        Cli::Server { port } => {
+            let server_channels_config = network_channels.server_channels();
+            let client_channels_config = network_channels.client_channels();
+
+            let server = RenetServer::new(ConnectionConfig {
+                server_channels_config,
+                client_channels_config,
+                ..Default::default()
+            });
+
+            let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
+            let public_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+            let socket = UdpSocket::bind(public_addr)?;
+            let server_config = ServerConfig {
+                max_clients: 4,
+                protocol_id: PROTOCOL_ID,
+                public_addr,
+                authentication: ServerAuthentication::Unsecure,
+            };
+            let transport = NetcodeServerTransport::new(current_time, server_config, socket)?;
+
+            commands.insert_resource(server);
+            commands.insert_resource(transport);
+
+            commands.spawn(TextBundle::from_section(
+                "Server",
+                TextStyle {
+                    font_size: 30.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+        }
+        Cli::Client { port, ip } => {
+            let server_channels_config = network_channels.server_channels();
+            let client_channels_config = network_channels.client_channels();
+
+            let client = RenetClient::new(ConnectionConfig {
+                server_channels_config,
+                client_channels_config,
+                ..Default::default()
+            });
+
+            let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
+            let client_id = current_time.as_millis() as u64;
+            let server_addr = SocketAddr::new(ip, port);
+            let socket = UdpSocket::bind((ip, 0))?;
+            let authentication = ClientAuthentication::Unsecure {
+                client_id,
+                protocol_id: PROTOCOL_ID,
+                server_addr,
+                user_data: None,
+            };
+            let transport = NetcodeClientTransport::new(current_time, authentication, socket)?;
+
+            commands.insert_resource(client);
+            commands.insert_resource(transport);
+
+            commands.spawn(TextBundle::from_section(
+                format!("Client: {client_id:?}"),
+                TextStyle {
+                    font_size: 30.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_client_or_single_player(
+) -> impl FnMut(Option<Res<RenetClient>>, Option<Res<RenetServer>>) -> bool + Clone {
+    move |client, server| client.is_some() || server.is_none()
+}

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -192,7 +192,7 @@ impl SimpleBoxPlugin {
         }
     }
 
-    /// Mutate [`PlayerPosition`] based on [`MoveCommandEvents`].
+    /// Mutates [`PlayerPosition`] based on [`MoveCommandEvents`].
     fn movement_system(
         time: Res<Time>,
         mut move_events: EventReader<FromClient<MoveDirection>>,

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -161,7 +161,7 @@ impl SimpleBoxPlugin {
         }
     }
 
-    fn draw_box_system(players: Query<(&PlayerPosition, &PlayerColor)>, mut gizmos: Gizmos) {
+    fn draw_box_system(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
         for (position, color) in players.iter() {
             gizmos.rect(
                 Vec3::new(position.x, position.y, 0.0),
@@ -173,7 +173,7 @@ impl SimpleBoxPlugin {
     }
 
     /// Reads player inputs and sends [`MoveCommandEvents`]
-    fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
+    fn input_system(mut move_event: EventWriter<MoveCommandEvent>, input: Res<Input<KeyCode>>) {
         let mut direction = Vec2::ZERO;
         if input.pressed(KeyCode::Right) {
             direction.x += 1.0;
@@ -196,9 +196,9 @@ impl SimpleBoxPlugin {
 
     /// Mutate [`PlayerPosition`] based on [`MoveCommandEvents`].
     fn movement_system(
+        time: Res<Time>,
         mut events: EventReader<FromClient<MoveCommandEvent>>,
         mut players: Query<(&Player, &mut PlayerPosition)>,
-        time: Res<Time>,
     ) {
         const MOVE_SPEED: f32 = 300.0;
         for FromClient { client_id, event } in &mut events {

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -143,7 +143,7 @@ impl SimpleBoxPlugin {
         for event in &mut server_event {
             match event {
                 ServerEvent::ClientConnected { client_id } => {
-                    info!("Player: {client_id} Connected");
+                    info!("player: {client_id} Connected");
                     // Generate pseudo random color from client id.
                     let r = ((client_id % 23) as f32) / 23.0;
                     let g = ((client_id % 27) as f32) / 27.0;
@@ -155,7 +155,7 @@ impl SimpleBoxPlugin {
                     ));
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {
-                    info!("Client {client_id} disconnected: {reason}");
+                    info!("client {client_id} disconnected: {reason}");
                 }
             }
         }

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -24,7 +24,7 @@ fn main() {
         .init_resource::<Cli>() // Parse CLI before creating window.
         .add_plugins(DefaultPlugins.build().set(WindowPlugin {
             primary_window: Some(Window {
-                title: "Move a Box".into(),
+                title: "Simple Box".into(),
                 resolution: (800.0, 600.0).into(),
                 ..Default::default()
             }),
@@ -35,13 +35,13 @@ fn main() {
                 .build()
                 .set(ServerPlugin::new(TickPolicy::MaxTickRate(60))),
         )
-        .add_plugins(MoveABoxPlugin)
+        .add_plugins(SimpleBoxPlugin)
         .run();
 }
 
-struct MoveABoxPlugin;
+struct SimpleBoxPlugin;
 
-impl Plugin for MoveABoxPlugin {
+impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate::<PlayerPosition>()
             .replicate::<PlayerColor>()

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -174,24 +174,20 @@ impl SimpleBoxPlugin {
 
     /// Reads player inputs and sends [`MoveCommandEvents`]
     fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
-        let right = input.pressed(KeyCode::Right);
-        let left = input.pressed(KeyCode::Left);
-        let up = input.pressed(KeyCode::Up);
-        let down = input.pressed(KeyCode::Down);
         let mut direction = Vec2::ZERO;
-        if right {
+        if input.pressed(KeyCode::Right) {
             direction.x += 1.0;
         }
-        if left {
+        if input.pressed(KeyCode::Left) {
             direction.x -= 1.0;
         }
-        if up {
+        if input.pressed(KeyCode::Up) {
             direction.y += 1.0;
         }
-        if down {
+        if input.pressed(KeyCode::Down) {
             direction.y -= 1.0;
         }
-        if right || left || up || down {
+        if direction != Vec2::ZERO {
             move_event.send(MoveCommandEvent {
                 direction: direction.normalize_or_zero(),
             })

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -45,7 +45,7 @@ impl Plugin for SimpleBoxPlugin {
                 (
                     Self::movement_system.run_if(has_authority()), // Runs only on the server or a single player.
                     Self::server_event_system.run_if(resource_exists::<RenetServer>()), // Runs only on the server.
-                    (Self::draw_box_system, Self::input_system),
+                    (Self::draw_boxes_system, Self::input_system),
                 ),
             );
     }
@@ -161,7 +161,7 @@ impl SimpleBoxPlugin {
         }
     }
 
-    fn draw_box_system(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
+    fn draw_boxes_system(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
         for (position, color) in &players {
             gizmos.rect(
                 Vec3::new(position.x, position.y, 0.0),

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -200,12 +200,12 @@ impl SimpleBoxPlugin {
         mut players: Query<(&Player, &mut PlayerPosition)>,
         time: Res<Time>,
     ) {
-        let move_speed = 300.0;
+        const MOVE_SPEED: f32 = 300.0;
         for FromClient { client_id, event } in &mut events {
             info!("received event {event:?} from client {client_id}");
             for (player, mut position) in players.iter_mut() {
                 if *client_id == **player {
-                    **position += event.direction * time.delta_seconds() * move_speed;
+                    **position += event.direction * time.delta_seconds() * MOVE_SPEED;
                 }
             }
         }

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -138,13 +138,13 @@ impl SimpleBoxPlugin {
         commands.spawn(Camera2dBundle::default());
     }
 
-    // Spawns a new player whenever a client connects
+    /// Logs server events and spawns a new player whenever a client connects.
     fn server_event_system(mut commands: Commands, mut server_event: EventReader<ServerEvent>) {
         for event in &mut server_event {
             match event {
                 ServerEvent::ClientConnected { client_id } => {
                     info!("Player: {client_id} Connected");
-                    // Generate pseudo random color from client id
+                    // Generate pseudo random color from client id.
                     let r = ((client_id % 23) as f32) / 23.0;
                     let g = ((client_id % 27) as f32) / 27.0;
                     let b = ((client_id % 39) as f32) / 39.0;
@@ -172,7 +172,7 @@ impl SimpleBoxPlugin {
         }
     }
 
-    // Read player inputs and publish MoveCommandEvents, only for client or single player instance
+    /// Reads player inputs and sends [`MoveCommandEvents`]
     fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
         let right = input.pressed(KeyCode::Right);
         let left = input.pressed(KeyCode::Left);
@@ -198,7 +198,7 @@ impl SimpleBoxPlugin {
         }
     }
 
-    // Mutate PlayerPosition based on MoveCommandEvents, runs on server or single player instance
+    /// Mutate [`PlayerPosition`] based on [`MoveCommandEvents`].
     fn movement_system(
         mut events: EventReader<FromClient<MoveCommandEvent>>,
         mut players: Query<(&Player, &mut PlayerPosition)>,
@@ -260,7 +260,7 @@ impl PlayerBundle {
     }
 }
 
-/// Contains the client ID of the player
+/// Contains the client ID of the player.
 #[derive(Component, Serialize, Deserialize, Deref)]
 struct Player(u64);
 

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -50,15 +50,14 @@ impl Plugin for SimpleBoxPlugin {
                 Startup,
                 (cli_system.pipe(system_adapter::unwrap), init_system),
             )
-            // Systems that run only on the server or a single player instance
-            .add_systems(Update, (movement_system).run_if(has_authority()))
-            // Systems that run only on the server
             .add_systems(
                 Update,
-                (server_event_system).run_if(resource_exists::<RenetServer>()),
-            )
-            // Systems that run everywhere
-            .add_systems(Update, (draw_box_system, input_system));
+                (
+                    movement_system.run_if(has_authority()), // Runs only on the server or a single player.
+                    server_event_system.run_if(resource_exists::<RenetServer>()), // Runs only on the server.
+                    (draw_box_system, input_system),
+                ),
+            );
     }
 }
 

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -35,129 +35,182 @@ impl Plugin for SimpleBoxPlugin {
             .add_client_event::<MoveCommandEvent>(SendPolicy::Ordered)
             .add_systems(
                 Startup,
-                (cli_system.pipe(system_adapter::unwrap), init_system),
+                (
+                    Self::cli_system.pipe(system_adapter::unwrap),
+                    Self::init_system,
+                ),
             )
             .add_systems(
                 Update,
                 (
-                    movement_system.run_if(has_authority()), // Runs only on the server or a single player.
-                    server_event_system.run_if(resource_exists::<RenetServer>()), // Runs only on the server.
-                    (draw_box_system, input_system),
+                    Self::movement_system.run_if(has_authority()), // Runs only on the server or a single player.
+                    Self::server_event_system.run_if(resource_exists::<RenetServer>()), // Runs only on the server.
+                    (Self::draw_box_system, Self::input_system),
                 ),
             );
     }
 }
 
-#[derive(Component, Deserialize, Serialize)]
-struct PlayerPosition(Vec2);
-
-#[derive(Component, Deserialize, Serialize)]
-struct PlayerColor(Color);
-
-/// Contains the client ID of the player
-#[derive(Component, Serialize, Deserialize)]
-struct Player(u64);
-
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    position: PlayerPosition,
-    color: PlayerColor,
-    replication: Replication,
-}
-
-impl PlayerBundle {
-    fn new(id: u64, position: Vec2, color: Color) -> Self {
-        Self {
-            player: Player(id),
-            position: PlayerPosition(position),
-            color: PlayerColor(color),
-            replication: Replication,
-        }
-    }
-}
-
-fn init_system(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
-}
-
-fn draw_box_system(q_net_pos: Query<(&PlayerPosition, &PlayerColor)>, mut gizmos: Gizmos) {
-    for (p, color) in q_net_pos.iter() {
-        gizmos.rect(
-            Vec3::new(p.0.x, p.0.y, 0.),
-            Quat::IDENTITY,
-            Vec2::ONE * 50.,
-            color.0,
-        );
-    }
-}
-
-#[derive(Debug, Default, Deserialize, Event, Serialize)]
-struct MoveCommandEvent {
-    pub direction: Vec2,
-}
-
-// Read player inputs and publish MoveCommandEvents, only for client or single player instance
-fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
-    let right = input.pressed(KeyCode::Right);
-    let left = input.pressed(KeyCode::Left);
-    let up = input.pressed(KeyCode::Up);
-    let down = input.pressed(KeyCode::Down);
-    let mut direction = Vec2::ZERO;
-    if right {
-        direction.x += 1.0;
-    }
-    if left {
-        direction.x -= 1.0;
-    }
-    if up {
-        direction.y += 1.0;
-    }
-    if down {
-        direction.y -= 1.0;
-    }
-    if right || left || up || down {
-        move_event.send(MoveCommandEvent {
-            direction: direction.normalize_or_zero(),
-        })
-    }
-}
-
-// Mutate PlayerPosition based on MoveCommandEvents, runs on server or single player instance
-fn movement_system(
-    mut events: EventReader<FromClient<MoveCommandEvent>>,
-    mut q_net_pos: Query<(&Player, &mut PlayerPosition)>,
-    time: Res<Time>,
-) {
-    let move_speed = 300.0;
-    for FromClient { client_id, event } in &mut events {
-        info!("received event {event:?} from client {client_id}");
-        for (player, mut position) in q_net_pos.iter_mut() {
-            if *client_id == player.0 {
-                position.0 += event.direction * time.delta_seconds() * move_speed;
+impl SimpleBoxPlugin {
+    fn cli_system(
+        mut commands: Commands,
+        cli: Res<Cli>,
+        network_channels: Res<NetworkChannels>,
+    ) -> Result<(), Box<dyn Error>> {
+        match *cli {
+            Cli::SinglePlayer => {
+                commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
             }
-        }
-    }
-}
+            Cli::Server { port } => {
+                let server_channels_config = network_channels.server_channels();
+                let client_channels_config = network_channels.client_channels();
 
-// Spawns a new player whenever a client connects
-fn server_event_system(mut commands: Commands, mut server_event: EventReader<ServerEvent>) {
-    for event in &mut server_event {
-        match event {
-            ServerEvent::ClientConnected { client_id } => {
-                info!("Player: {client_id} Connected");
-                // Generate pseudo random color from client id
-                let r = ((client_id % 23) as f32) / 23.;
-                let g = ((client_id % 27) as f32) / 27.;
-                let b = ((client_id % 39) as f32) / 39.;
-                commands.spawn(PlayerBundle::new(
-                    *client_id,
-                    Vec2::ZERO,
-                    Color::rgb(r, g, b),
+                let server = RenetServer::new(ConnectionConfig {
+                    server_channels_config,
+                    client_channels_config,
+                    ..Default::default()
+                });
+
+                let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
+                let public_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
+                let socket = UdpSocket::bind(public_addr)?;
+                let server_config = ServerConfig {
+                    max_clients: 10,
+                    protocol_id: PROTOCOL_ID,
+                    public_addr,
+                    authentication: ServerAuthentication::Unsecure,
+                };
+                let transport = NetcodeServerTransport::new(current_time, server_config, socket)?;
+
+                commands.insert_resource(server);
+                commands.insert_resource(transport);
+
+                commands.spawn(TextBundle::from_section(
+                    "Server",
+                    TextStyle {
+                        font_size: 30.0,
+                        color: Color::WHITE,
+                        ..default()
+                    },
+                ));
+                commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
+            }
+            Cli::Client { port, ip } => {
+                let server_channels_config = network_channels.server_channels();
+                let client_channels_config = network_channels.client_channels();
+
+                let client = RenetClient::new(ConnectionConfig {
+                    server_channels_config,
+                    client_channels_config,
+                    ..Default::default()
+                });
+
+                let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
+                let client_id = current_time.as_millis() as u64;
+                let server_addr = SocketAddr::new(ip, port);
+                let socket = UdpSocket::bind((ip, 0))?;
+                let authentication = ClientAuthentication::Unsecure {
+                    client_id,
+                    protocol_id: PROTOCOL_ID,
+                    server_addr,
+                    user_data: None,
+                };
+                let transport = NetcodeClientTransport::new(current_time, authentication, socket)?;
+
+                commands.insert_resource(client);
+                commands.insert_resource(transport);
+
+                commands.spawn(TextBundle::from_section(
+                    format!("Client: {client_id:?}"),
+                    TextStyle {
+                        font_size: 30.0,
+                        color: Color::WHITE,
+                        ..default()
+                    },
                 ));
             }
-            ServerEvent::ClientDisconnected { client_id, reason } => {
-                info!("Client {client_id} disconnected: {reason}");
+        }
+
+        Ok(())
+    }
+
+    fn init_system(mut commands: Commands) {
+        commands.spawn(Camera2dBundle::default());
+    }
+
+    // Spawns a new player whenever a client connects
+    fn server_event_system(mut commands: Commands, mut server_event: EventReader<ServerEvent>) {
+        for event in &mut server_event {
+            match event {
+                ServerEvent::ClientConnected { client_id } => {
+                    info!("Player: {client_id} Connected");
+                    // Generate pseudo random color from client id
+                    let r = ((client_id % 23) as f32) / 23.;
+                    let g = ((client_id % 27) as f32) / 27.;
+                    let b = ((client_id % 39) as f32) / 39.;
+                    commands.spawn(PlayerBundle::new(
+                        *client_id,
+                        Vec2::ZERO,
+                        Color::rgb(r, g, b),
+                    ));
+                }
+                ServerEvent::ClientDisconnected { client_id, reason } => {
+                    info!("Client {client_id} disconnected: {reason}");
+                }
+            }
+        }
+    }
+
+    fn draw_box_system(q_net_pos: Query<(&PlayerPosition, &PlayerColor)>, mut gizmos: Gizmos) {
+        for (p, color) in q_net_pos.iter() {
+            gizmos.rect(
+                Vec3::new(p.0.x, p.0.y, 0.),
+                Quat::IDENTITY,
+                Vec2::ONE * 50.,
+                color.0,
+            );
+        }
+    }
+
+    // Read player inputs and publish MoveCommandEvents, only for client or single player instance
+    fn input_system(input: Res<Input<KeyCode>>, mut move_event: EventWriter<MoveCommandEvent>) {
+        let right = input.pressed(KeyCode::Right);
+        let left = input.pressed(KeyCode::Left);
+        let up = input.pressed(KeyCode::Up);
+        let down = input.pressed(KeyCode::Down);
+        let mut direction = Vec2::ZERO;
+        if right {
+            direction.x += 1.0;
+        }
+        if left {
+            direction.x -= 1.0;
+        }
+        if up {
+            direction.y += 1.0;
+        }
+        if down {
+            direction.y -= 1.0;
+        }
+        if right || left || up || down {
+            move_event.send(MoveCommandEvent {
+                direction: direction.normalize_or_zero(),
+            })
+        }
+    }
+
+    // Mutate PlayerPosition based on MoveCommandEvents, runs on server or single player instance
+    fn movement_system(
+        mut events: EventReader<FromClient<MoveCommandEvent>>,
+        mut q_net_pos: Query<(&Player, &mut PlayerPosition)>,
+        time: Res<Time>,
+    ) {
+        let move_speed = 300.0;
+        for FromClient { client_id, event } in &mut events {
+            info!("received event {event:?} from client {client_id}");
+            for (player, mut position) in q_net_pos.iter_mut() {
+                if *client_id == player.0 {
+                    position.0 += event.direction * time.delta_seconds() * move_speed;
+                }
             }
         }
     }
@@ -188,84 +241,36 @@ impl Default for Cli {
     }
 }
 
-fn cli_system(
-    mut commands: Commands,
-    cli: Res<Cli>,
-    network_channels: Res<NetworkChannels>,
-) -> Result<(), Box<dyn Error>> {
-    match *cli {
-        Cli::SinglePlayer => {
-            commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
-        }
-        Cli::Server { port } => {
-            let server_channels_config = network_channels.server_channels();
-            let client_channels_config = network_channels.client_channels();
+#[derive(Bundle)]
+struct PlayerBundle {
+    player: Player,
+    position: PlayerPosition,
+    color: PlayerColor,
+    replication: Replication,
+}
 
-            let server = RenetServer::new(ConnectionConfig {
-                server_channels_config,
-                client_channels_config,
-                ..Default::default()
-            });
-
-            let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-            let public_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
-            let socket = UdpSocket::bind(public_addr)?;
-            let server_config = ServerConfig {
-                max_clients: 10,
-                protocol_id: PROTOCOL_ID,
-                public_addr,
-                authentication: ServerAuthentication::Unsecure,
-            };
-            let transport = NetcodeServerTransport::new(current_time, server_config, socket)?;
-
-            commands.insert_resource(server);
-            commands.insert_resource(transport);
-
-            commands.spawn(TextBundle::from_section(
-                "Server",
-                TextStyle {
-                    font_size: 30.0,
-                    color: Color::WHITE,
-                    ..default()
-                },
-            ));
-            commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
-        }
-        Cli::Client { port, ip } => {
-            let server_channels_config = network_channels.server_channels();
-            let client_channels_config = network_channels.client_channels();
-
-            let client = RenetClient::new(ConnectionConfig {
-                server_channels_config,
-                client_channels_config,
-                ..Default::default()
-            });
-
-            let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-            let client_id = current_time.as_millis() as u64;
-            let server_addr = SocketAddr::new(ip, port);
-            let socket = UdpSocket::bind((ip, 0))?;
-            let authentication = ClientAuthentication::Unsecure {
-                client_id,
-                protocol_id: PROTOCOL_ID,
-                server_addr,
-                user_data: None,
-            };
-            let transport = NetcodeClientTransport::new(current_time, authentication, socket)?;
-
-            commands.insert_resource(client);
-            commands.insert_resource(transport);
-
-            commands.spawn(TextBundle::from_section(
-                format!("Client: {client_id:?}"),
-                TextStyle {
-                    font_size: 30.0,
-                    color: Color::WHITE,
-                    ..default()
-                },
-            ));
+impl PlayerBundle {
+    fn new(id: u64, position: Vec2, color: Color) -> Self {
+        Self {
+            player: Player(id),
+            position: PlayerPosition(position),
+            color: PlayerColor(color),
+            replication: Replication,
         }
     }
+}
 
-    Ok(())
+/// Contains the client ID of the player
+#[derive(Component, Serialize, Deserialize)]
+struct Player(u64);
+
+#[derive(Component, Deserialize, Serialize)]
+struct PlayerPosition(Vec2);
+
+#[derive(Component, Deserialize, Serialize)]
+struct PlayerColor(Color);
+
+#[derive(Debug, Default, Deserialize, Event, Serialize)]
+struct MoveCommandEvent {
+    pub direction: Vec2,
 }

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -1,3 +1,6 @@
+//! A simple demo to showcase how player could send inputs to move the square and server replicates position back.
+//! Also demonstrates the single-player and how sever also could be a player.
+
 use std::{
     error::Error,
     net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -193,6 +196,9 @@ impl SimpleBoxPlugin {
     }
 
     /// Mutates [`PlayerPosition`] based on [`MoveCommandEvents`].
+    ///
+    /// Fast-paced games usually you don't want to wait until server send a position back because of the latency.
+    /// But this example just demonstrates simple replication concept.
     fn movement_system(
         time: Res<Time>,
         mut move_events: EventReader<FromClient<MoveDirection>>,

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -145,9 +145,9 @@ impl SimpleBoxPlugin {
                 ServerEvent::ClientConnected { client_id } => {
                     info!("Player: {client_id} Connected");
                     // Generate pseudo random color from client id
-                    let r = ((client_id % 23) as f32) / 23.;
-                    let g = ((client_id % 27) as f32) / 27.;
-                    let b = ((client_id % 39) as f32) / 39.;
+                    let r = ((client_id % 23) as f32) / 23.0;
+                    let g = ((client_id % 27) as f32) / 27.0;
+                    let b = ((client_id % 39) as f32) / 39.0;
                     commands.spawn(PlayerBundle::new(
                         *client_id,
                         Vec2::ZERO,

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -167,7 +167,7 @@ impl SimpleBoxPlugin {
                 Vec3::new(position.x, position.y, 0.0),
                 Quat::IDENTITY,
                 Vec2::ONE * 50.0,
-                **color,
+                color.0,
             );
         }
     }
@@ -202,7 +202,7 @@ impl SimpleBoxPlugin {
         for FromClient { client_id, event } in &mut move_events {
             info!("received event {event:?} from client {client_id}");
             for (player, mut position) in players.iter_mut() {
-                if *client_id == **player {
+                if *client_id == player.0 {
                     **position += event.0 * time.delta_seconds() * MOVE_SPEED;
                 }
             }
@@ -255,13 +255,13 @@ impl PlayerBundle {
 }
 
 /// Contains the client ID of the player.
-#[derive(Component, Serialize, Deserialize, Deref)]
+#[derive(Component, Serialize, Deserialize)]
 struct Player(u64);
 
 #[derive(Component, Deserialize, Serialize, Deref, DerefMut)]
 struct PlayerPosition(Vec2);
 
-#[derive(Component, Deserialize, Serialize, Deref)]
+#[derive(Component, Deserialize, Serialize)]
 struct PlayerColor(Color);
 
 /// A movement event for the controlled box.

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -59,7 +59,7 @@ impl SimpleBoxPlugin {
     ) -> Result<(), Box<dyn Error>> {
         match *cli {
             Cli::SinglePlayer => {
-                commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
+                commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Server { port } => {
                 let server_channels_config = network_channels.server_channels();
@@ -93,7 +93,7 @@ impl SimpleBoxPlugin {
                         ..default()
                     },
                 ));
-                commands.spawn(PlayerBundle::new(0, Vec2::ZERO, Color::GREEN));
+                commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Client { port, ip } => {
                 let server_channels_config = network_channels.server_channels();

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -22,20 +22,7 @@ use bevy_replicon::{
 fn main() {
     App::new()
         .init_resource::<Cli>() // Parse CLI before creating window.
-        .add_plugins(DefaultPlugins.build().set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "Simple Box".into(),
-                resolution: (800.0, 600.0).into(),
-                ..Default::default()
-            }),
-            ..Default::default()
-        }))
-        .add_plugins(
-            ReplicationPlugins
-                .build()
-                .set(ServerPlugin::new(TickPolicy::MaxTickRate(60))),
-        )
-        .add_plugins(SimpleBoxPlugin)
+        .add_plugins((DefaultPlugins, ReplicationPlugins, SimpleBoxPlugin))
         .run();
 }
 

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -162,7 +162,7 @@ impl SimpleBoxPlugin {
     }
 
     fn draw_box_system(mut gizmos: Gizmos, players: Query<(&PlayerPosition, &PlayerColor)>) {
-        for (position, color) in players.iter() {
+        for (position, color) in &players {
             gizmos.rect(
                 Vec3::new(position.x, position.y, 0.0),
                 Quat::IDENTITY,
@@ -201,7 +201,7 @@ impl SimpleBoxPlugin {
         const MOVE_SPEED: f32 = 300.0;
         for FromClient { client_id, event } in &mut move_events {
             info!("received event {event:?} from client {client_id}");
-            for (player, mut position) in players.iter_mut() {
+            for (player, mut position) in &mut players {
                 if *client_id == player.0 {
                     **position += event.0 * time.delta_seconds() * MOVE_SPEED;
                 }


### PR DESCRIPTION
I initially implemented this example for my own understanding but it might also be a useful addition to this repo.
It has some common code with the tic-tac-toe example but shows a few different concepts and is a little less complex.

It's features are:
- Spawn a new player entity with position and color components whenever a new client connects
- Render the player positions as simple colored boxes 
- Allow Inputs through the arrows keys on clients only and send a server event
- Process movement on server only and sync with clients through replication
- Single Player Mode

Maybe it helps :)
Keep up the great work with this lib!