### PR TITLE
Client Diagnostics plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `ClientDiagnosticsPlugin`, which writes diagnostics every second.
+
 ## [0.14.0] - 2023-10-05
 
 ### Added

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,9 +63,9 @@ impl ClientPlugin {
                         let end_pos: u64 = message.len().try_into().unwrap();
                         let mut cursor = Cursor::new(message);
 
-                        if let Some(ref mut rs) = stats {
-                            rs.packets += 1;
-                            rs.bytes += end_pos as u32;
+                        if let Some(stats) = &mut stats {
+                            stats.packets += 1;
+                            stats.bytes += end_pos as u32;
                         }
 
                         let Some(tick) = apply_tick(&mut cursor, world)? else {

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use crate::replicon_core::{
 };
 
 pub(crate) mod diagnostics;
-pub use diagnostics::{ClientDiagnosticsPlugin, ReplicationStats};
+pub use diagnostics::{ClientDiagnosticsPlugin, ClientStats};
 
 pub struct ClientPlugin;
 
@@ -58,7 +58,7 @@ impl ClientPlugin {
         world.resource_scope(|world, mut client: Mut<RenetClient>| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
                 world.resource_scope(|world, replication_rules: Mut<ReplicationRules>| {
-                    let mut stats = world.remove_resource::<ReplicationStats>();
+                    let mut stats = world.remove_resource::<ClientStats>();
                     while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
                         let end_pos: u64 = message.len().try_into().unwrap();
                         let mut cursor = Cursor::new(message);
@@ -164,7 +164,7 @@ fn apply_entity_mappings(
     cursor: &mut Cursor<Bytes>,
     world: &mut World,
     entity_map: &mut ServerEntityMap,
-    stats: &mut Option<ReplicationStats>,
+    stats: &mut Option<ClientStats>,
 ) -> Result<(), bincode::Error> {
     let array_len: u16 = bincode::deserialize_from(&mut *cursor)?;
     if let Some(rs) = stats {
@@ -202,7 +202,7 @@ fn apply_component_diffs(
     replication_rules: &ReplicationRules,
     diff_kind: DiffKind,
     tick: RepliconTick,
-    stats: &mut Option<ReplicationStats>,
+    stats: &mut Option<ClientStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
     for _ in 0..entities_count {
@@ -236,7 +236,7 @@ fn apply_despawns(
     entity_map: &mut ServerEntityMap,
     replication_rules: &ReplicationRules,
     tick: RepliconTick,
-    stats: &mut Option<ReplicationStats>,
+    stats: &mut Option<ClientStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
     if let Some(rs) = stats {

--- a/src/client.rs
+++ b/src/client.rs
@@ -111,7 +111,7 @@ impl ClientPlugin {
                             &mut entity_map,
                             &replication_rules,
                             tick,
-                            &mut stats,
+                            stats.as_mut(),
                         )?;
                     }
 
@@ -235,7 +235,7 @@ fn apply_despawns(
     entity_map: &mut ServerEntityMap,
     replication_rules: &ReplicationRules,
     tick: RepliconTick,
-    stats: &mut Option<ClientStats>,
+    stats: Option<&mut ClientStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
     if let Some(stats) = stats {

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,63 +59,69 @@ impl ClientPlugin {
         world.resource_scope(|world, mut client: Mut<RenetClient>| {
             world.resource_scope(|world, mut entity_map: Mut<ServerEntityMap>| {
                 world.resource_scope(|world, replication_rules: Mut<ReplicationRules>| {
-                    world.resource_scope(|world, mut stats: Mut<ReplicationStats>| {
-                        while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
-                            let end_pos: u64 = message.len().try_into().unwrap();
-                            let mut cursor = Cursor::new(message);
+                    let mut stats = world.remove_resource::<ReplicationStats>();
+                    while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
+                        let end_pos: u64 = message.len().try_into().unwrap();
+                        let mut cursor = Cursor::new(message);
 
-                            let Some(tick) = apply_tick(&mut cursor, world)? else {
-                                continue;
-                            };
-                            stats.packets += 1;
-
-                            if cursor.position() == end_pos {
-                                continue;
-                            }
-
-                            apply_entity_mappings(&mut cursor, world, &mut entity_map, &mut stats)?;
-
-                            if cursor.position() == end_pos {
-                                continue;
-                            }
-
-                            apply_component_diffs(
-                                &mut cursor,
-                                world,
-                                &mut entity_map,
-                                &replication_rules,
-                                DiffKind::Change,
-                                tick,
-                                &mut stats,
-                            )?;
-                            if cursor.position() == end_pos {
-                                continue;
-                            }
-
-                            apply_component_diffs(
-                                &mut cursor,
-                                world,
-                                &mut entity_map,
-                                &replication_rules,
-                                DiffKind::Removal,
-                                tick,
-                                &mut stats,
-                            )?;
-                            if cursor.position() == end_pos {
-                                continue;
-                            }
-
-                            apply_despawns(
-                                &mut cursor,
-                                world,
-                                &mut entity_map,
-                                &replication_rules,
-                                tick,
-                                &mut stats,
-                            )?;
+                        if let Some(ref mut rs) = stats {
+                            rs.packets += 1;
+                            rs.bytes += end_pos as u32;
                         }
-                        Ok(())
-                    })
+
+                        let Some(tick) = apply_tick(&mut cursor, world)? else {
+                                continue;
+                        };
+
+                        if cursor.position() == end_pos {
+                            continue;
+                        }
+
+                        apply_entity_mappings(&mut cursor, world, &mut entity_map, &mut stats)?;
+
+                        if cursor.position() == end_pos {
+                            continue;
+                        }
+
+                        apply_component_diffs(
+                            &mut cursor,
+                            world,
+                            &mut entity_map,
+                            &replication_rules,
+                            DiffKind::Change,
+                            tick,
+                            &mut stats,
+                        )?;
+                        if cursor.position() == end_pos {
+                            continue;
+                        }
+
+                        apply_component_diffs(
+                            &mut cursor,
+                            world,
+                            &mut entity_map,
+                            &replication_rules,
+                            DiffKind::Removal,
+                            tick,
+                            &mut stats,
+                        )?;
+                        if cursor.position() == end_pos {
+                            continue;
+                        }
+
+                        apply_despawns(
+                            &mut cursor,
+                            world,
+                            &mut entity_map,
+                            &replication_rules,
+                            tick,
+                            &mut stats,
+                        )?;
+                    }
+                    if let Some(rs) = stats {
+                        world.insert_resource(rs);
+                    }
+                    Ok(())
                 })
             })
         })
@@ -159,10 +165,12 @@ fn apply_entity_mappings(
     cursor: &mut Cursor<Bytes>,
     world: &mut World,
     entity_map: &mut ServerEntityMap,
-    stats: &mut ReplicationStats,
+    stats: &mut Option<ReplicationStats>,
 ) -> Result<(), bincode::Error> {
     let array_len: u16 = bincode::deserialize_from(&mut *cursor)?;
-    stats.mappings += array_len as u32;
+    if let Some(rs) = stats {
+        rs.mappings += array_len as u32;
+    }
     for _ in 0..array_len {
         let server_entity = read_entity(cursor)?;
         let client_entity = read_entity(cursor)?;
@@ -195,15 +203,17 @@ fn apply_component_diffs(
     replication_rules: &ReplicationRules,
     diff_kind: DiffKind,
     tick: RepliconTick,
-    stats: &mut ReplicationStats,
+    stats: &mut Option<ReplicationStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
-    stats.entities_changed += entities_count as u32;
     for _ in 0..entities_count {
         let entity = read_entity(cursor)?;
         let mut entity = entity_map.get_by_server_or_spawn(world, entity);
         let components_count: u8 = bincode::deserialize_from(&mut *cursor)?;
-        stats.components_changed += components_count as u32;
+        if let Some(rs) = stats {
+            rs.entities_changed += 1;
+            rs.components_changed += components_count as u32;
+        }
         for _ in 0..components_count {
             let replication_id = DefaultOptions::new().deserialize_from(&mut *cursor)?;
             // SAFETY: server and client have identical `ReplicationRules` and server always sends valid IDs.
@@ -227,10 +237,12 @@ fn apply_despawns(
     entity_map: &mut ServerEntityMap,
     replication_rules: &ReplicationRules,
     tick: RepliconTick,
-    stats: &mut ReplicationStats,
+    stats: &mut Option<ReplicationStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
-    stats.despawns += entities_count as u32;
+    if let Some(rs) = stats {
+        rs.despawns += entities_count as u32;
+    }
     for _ in 0..entities_count {
         // The entity might have already been despawned because of hierarchy or
         // with the last diff, but the server might not yet have received confirmation

--- a/src/client.rs
+++ b/src/client.rs
@@ -117,8 +117,8 @@ impl ClientPlugin {
                             &mut stats,
                         )?;
                     }
-                    if let Some(rs) = stats {
-                        world.insert_resource(rs);
+                    if let Some(stats) = stats {
+                        world.insert_resource(stats);
                     }
                     Ok(())
                 })
@@ -167,8 +167,8 @@ fn apply_entity_mappings(
     stats: &mut Option<ClientStats>,
 ) -> Result<(), bincode::Error> {
     let array_len: u16 = bincode::deserialize_from(&mut *cursor)?;
-    if let Some(rs) = stats {
-        rs.mappings += array_len as u32;
+    if let Some(stats) = stats {
+        stats.mappings += array_len as u32;
     }
     for _ in 0..array_len {
         let server_entity = read_entity(cursor)?;
@@ -209,9 +209,9 @@ fn apply_component_diffs(
         let entity = read_entity(cursor)?;
         let mut entity = entity_map.get_by_server_or_spawn(world, entity);
         let components_count: u8 = bincode::deserialize_from(&mut *cursor)?;
-        if let Some(rs) = stats {
-            rs.entities_changed += 1;
-            rs.components_changed += components_count as u32;
+        if let Some(stats) = stats {
+            stats.entities_changed += 1;
+            stats.components_changed += components_count as u32;
         }
         for _ in 0..components_count {
             let replication_id = DefaultOptions::new().deserialize_from(&mut *cursor)?;
@@ -239,8 +239,8 @@ fn apply_despawns(
     stats: &mut Option<ClientStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
-    if let Some(rs) = stats {
-        rs.despawns += entities_count as u32;
+    if let Some(stats) = stats {
+        stats.despawns += entities_count as u32;
     }
     for _ in 0..entities_count {
         // The entity might have already been despawned because of hierarchy or

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,6 +17,7 @@ use crate::replicon_core::{
     replicon_tick::RepliconTick,
     REPLICATION_CHANNEL_ID,
 };
+use diagnostics::ClientStats;
 
 pub struct ClientPlugin;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use crate::replicon_core::{
 };
 
 pub(crate) mod diagnostics;
-use diagnostics::{ReplicationStats, ReplicationStatsPlugin};
+use diagnostics::ReplicationStats;
 
 pub struct ClientPlugin;
 
@@ -26,7 +26,6 @@ impl Plugin for ClientPlugin {
         app.add_plugins((RenetClientPlugin, NetcodeClientPlugin))
             .init_resource::<LastRepliconTick>()
             .init_resource::<ServerEntityMap>()
-            .add_plugins(ReplicationStatsPlugin)
             .configure_set(
                 PreUpdate,
                 ClientSet::Receive.after(NetcodeClientPlugin::update_system),

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,7 +65,7 @@ impl ClientPlugin {
 
                         if let Some(stats) = &mut stats {
                             stats.packets += 1;
-                            stats.bytes += end_pos as u32;
+                            stats.bytes += end_pos;
                         }
 
                         let Some(tick) = apply_tick(&mut cursor, world)? else {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,5 @@
+pub mod diagnostics;
+
 use std::io::Cursor;
 
 use bevy::{
@@ -15,9 +17,6 @@ use crate::replicon_core::{
     replicon_tick::RepliconTick,
     REPLICATION_CHANNEL_ID,
 };
-
-pub(crate) mod diagnostics;
-pub use diagnostics::{ClientDiagnosticsPlugin, ClientStats};
 
 pub struct ClientPlugin;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,7 @@ use crate::replicon_core::{
 };
 
 pub(crate) mod diagnostics;
-use diagnostics::ReplicationStats;
+pub use diagnostics::{ClientDiagnosticsPlugin, ReplicationStats};
 
 pub struct ClientPlugin;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,7 +74,7 @@ impl ClientPlugin {
                             continue;
                         }
 
-                        apply_entity_mappings(&mut cursor, world, &mut entity_map, &mut stats)?;
+                        apply_entity_mappings(&mut cursor, world, &mut entity_map, stats.as_mut())?;
                         if cursor.position() == end_pos {
                             continue;
                         }
@@ -86,7 +86,7 @@ impl ClientPlugin {
                             &replication_rules,
                             DiffKind::Change,
                             tick,
-                            &mut stats,
+                            stats.as_mut(),
                         )?;
                         if cursor.position() == end_pos {
                             continue;
@@ -99,7 +99,7 @@ impl ClientPlugin {
                             &replication_rules,
                             DiffKind::Removal,
                             tick,
-                            &mut stats,
+                            stats.as_mut(),
                         )?;
                         if cursor.position() == end_pos {
                             continue;
@@ -163,7 +163,7 @@ fn apply_entity_mappings(
     cursor: &mut Cursor<Bytes>,
     world: &mut World,
     entity_map: &mut ServerEntityMap,
-    stats: &mut Option<ClientStats>,
+    stats: Option<&mut ClientStats>,
 ) -> Result<(), bincode::Error> {
     let array_len: u16 = bincode::deserialize_from(&mut *cursor)?;
     if let Some(stats) = stats {
@@ -201,14 +201,14 @@ fn apply_component_diffs(
     replication_rules: &ReplicationRules,
     diff_kind: DiffKind,
     tick: RepliconTick,
-    stats: &mut Option<ClientStats>,
+    mut stats: Option<&mut ClientStats>,
 ) -> Result<(), bincode::Error> {
     let entities_count: u16 = bincode::deserialize_from(&mut *cursor)?;
     for _ in 0..entities_count {
         let entity = read_entity(cursor)?;
         let mut entity = entity_map.get_by_server_or_spawn(world, entity);
         let components_count: u8 = bincode::deserialize_from(&mut *cursor)?;
-        if let Some(stats) = stats {
+        if let Some(stats) = &mut stats {
             stats.entities_changed += 1;
             stats.components_changed += components_count as u32;
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -62,7 +62,6 @@ impl ClientPlugin {
                     while let Some(message) = client.receive_message(REPLICATION_CHANNEL_ID) {
                         let end_pos: u64 = message.len().try_into().unwrap();
                         let mut cursor = Cursor::new(message);
-
                         if let Some(stats) = &mut stats {
                             stats.packets += 1;
                             stats.bytes += end_pos;
@@ -71,13 +70,11 @@ impl ClientPlugin {
                         let Some(tick) = apply_tick(&mut cursor, world)? else {
                             continue;
                         };
-
                         if cursor.position() == end_pos {
                             continue;
                         }
 
                         apply_entity_mappings(&mut cursor, world, &mut entity_map, &mut stats)?;
-
                         if cursor.position() == end_pos {
                             continue;
                         }
@@ -117,9 +114,11 @@ impl ClientPlugin {
                             &mut stats,
                         )?;
                     }
+
                     if let Some(stats) = stats {
                         world.insert_resource(stats);
                     }
+
                     Ok(())
                 })
             })

--- a/src/client.rs
+++ b/src/client.rs
@@ -69,7 +69,7 @@ impl ClientPlugin {
                         }
 
                         let Some(tick) = apply_tick(&mut cursor, world)? else {
-                                continue;
+                            continue;
                         };
 
                         if cursor.position() == end_pos {

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -1,0 +1,120 @@
+use bevy::diagnostic::DiagnosticId;
+use bevy::{
+    diagnostic::{Diagnostic, Diagnostics, RegisterDiagnostic},
+    prelude::*,
+    time::common_conditions::on_timer,
+};
+use std::time::Duration;
+
+/// Collects replication stats during packet processing
+/// flushed to Diagnostics system periodically.
+#[derive(Default, Resource, Debug)]
+pub struct ReplicationStats {
+    // incremented per entity that changes
+    pub entities_changed: u32,
+    // incremented for every component that changes
+    pub components_changed: u32,
+    // incremented per client mapping added
+    pub mappings: u32,
+    // incrementer per entity despawn
+    pub despawns: u32,
+    // replication packets recvd
+    pub packets: u32,
+}
+
+pub mod replication_diagnostics {
+    use super::*;
+    /// How many entities modified per second by replication
+    pub const REPLICATED_ENTITY_CHANGES_DIAGNOSTIC: DiagnosticId =
+        DiagnosticId::from_u128(87359945710349305342211647237348);
+    /// How many components modified per second by replication
+    pub const REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC: DiagnosticId =
+        DiagnosticId::from_u128(36575095059706152186806005753628);
+    /// How many client-mappings added per second by replication
+    pub const REPLICATED_MAPPINGS_DIAGNOSTIC: DiagnosticId =
+        DiagnosticId::from_u128(61564098061172206743744706749187);
+    /// How many despawns per second from replication
+    pub const REPLICATED_DESPAWNS_DIAGNOSTIC: DiagnosticId =
+        DiagnosticId::from_u128(11043323327351349675112378115868);
+    /// How many replication packets processed per second
+    pub const REPLICATED_PACKETS_DIAGNOSTIC: DiagnosticId =
+        DiagnosticId::from_u128(40094818756895929689855772983865);
+
+    /// Diagnostic max_history_length
+    pub const REPLICATED_DIAGNOSTIC_HISTORY_LEN: usize = 60;
+}
+
+use replication_diagnostics::*;
+
+#[derive(Default)]
+pub(super) struct ReplicationStatsPlugin;
+
+impl Plugin for ReplicationStatsPlugin {
+    fn build(&self, app: &mut App) {
+        let diagnostics_timer = Duration::from_millis(1000);
+        app.add_systems(
+            Update,
+            write_diagnostics.run_if(on_timer(diagnostics_timer)),
+        )
+        .init_resource::<ReplicationStats>()
+        .register_diagnostic(Diagnostic::new(
+            REPLICATED_ENTITY_CHANGES_DIAGNOSTIC,
+            "entities changed per second",
+            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+        ))
+        .register_diagnostic(Diagnostic::new(
+            REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC,
+            "components changed per second",
+            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+        ))
+        .register_diagnostic(Diagnostic::new(
+            REPLICATED_MAPPINGS_DIAGNOSTIC,
+            "mappings added per second",
+            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+        ))
+        .register_diagnostic(Diagnostic::new(
+            REPLICATED_DESPAWNS_DIAGNOSTIC,
+            "despawns per second",
+            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+        ))
+        .register_diagnostic(Diagnostic::new(
+            REPLICATED_PACKETS_DIAGNOSTIC,
+            "packets per second",
+            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+        ));
+    }
+}
+
+/// flushes aggregated stats to diagnostics system
+fn write_diagnostics(mut stats: ResMut<ReplicationStats>, mut diagnostics: Diagnostics) {
+    diagnostics.add_measurement(REPLICATED_ENTITY_CHANGES_DIAGNOSTIC, || {
+        if stats.packets == 0 {
+            0_f64
+        } else {
+            stats.entities_changed as f64 / stats.packets as f64
+        }
+    });
+    diagnostics.add_measurement(REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC, || {
+        if stats.packets == 0 {
+            0_f64
+        } else {
+            stats.components_changed as f64 / stats.packets as f64
+        }
+    });
+    diagnostics.add_measurement(REPLICATED_MAPPINGS_DIAGNOSTIC, || {
+        if stats.packets == 0 {
+            0_f64
+        } else {
+            stats.mappings as f64 / stats.packets as f64
+        }
+    });
+    diagnostics.add_measurement(REPLICATED_DESPAWNS_DIAGNOSTIC, || {
+        if stats.packets == 0 {
+            0_f64
+        } else {
+            stats.despawns as f64 / stats.packets as f64
+        }
+    });
+    diagnostics.add_measurement(REPLICATED_PACKETS_DIAGNOSTIC, || stats.packets as f64);
+    *stats = ReplicationStats::default();
+}

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -24,6 +24,7 @@ pub struct ReplicationStats {
     pub bytes: u32,
 }
 
+/// Diagnostic IDs for per-second replication diagnostics
 pub mod replication_diagnostics {
     use super::*;
     /// How many entities modified per second by replication
@@ -51,6 +52,10 @@ pub mod replication_diagnostics {
 
 use replication_diagnostics::*;
 
+/// Clientside plugin to write Diagnostics every second
+/// Not added by default.
+///
+/// See [`replication_diagnostics`]
 #[derive(Default)]
 pub(super) struct ReplicationStatsPlugin;
 

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 ///
 /// Flushed to Diagnostics system periodically.
 #[derive(Default, Resource, Debug)]
-pub struct ReplicationStats {
+pub struct ClientStats {
     /// Incremented per entity that changes.
     pub entities_changed: u32,
     /// Incremented for every component that changes.
@@ -38,7 +38,7 @@ impl Plugin for ClientDiagnosticsPlugin {
             Update,
             Self::diagnostic_system.run_if(on_timer(diagnostics_timer)),
         )
-        .init_resource::<ReplicationStats>()
+        .init_resource::<ClientStats>()
         .register_diagnostic(Diagnostic::new(
             Self::ENTITY_CHANGES,
             "entities changed per second",
@@ -91,7 +91,7 @@ impl ClientDiagnosticsPlugin {
     /// Diagnostic max_history_length
     pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
 
-    fn diagnostic_system(mut stats: ResMut<ReplicationStats>, mut diagnostics: Diagnostics) {
+    fn diagnostic_system(mut stats: ResMut<ClientStats>, mut diagnostics: Diagnostics) {
         diagnostics.add_measurement(Self::ENTITY_CHANGES, || {
             if stats.packets == 0 {
                 0_f64
@@ -128,6 +128,6 @@ impl ClientDiagnosticsPlugin {
             }
         });
         diagnostics.add_measurement(Self::PACKETS, || stats.packets as f64);
-        *stats = ReplicationStats::default();
+        *stats = ClientStats::default();
     }
 }

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -26,12 +26,12 @@ pub struct ReplicationStats {
     pub bytes: u32,
 }
 
-/// Clientside plugin to write Diagnostics every second
+/// Plugin to write Diagnostics every second.
 /// Not added by default.
 #[derive(Default)]
-pub struct ReplicationDiagnosticsPlugin;
+pub struct ClientDiagnosticsPlugin;
 
-impl Plugin for ReplicationDiagnosticsPlugin {
+impl Plugin for ClientDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         let diagnostics_timer = Duration::from_millis(1000);
         app.add_systems(
@@ -72,7 +72,7 @@ impl Plugin for ReplicationDiagnosticsPlugin {
     }
 }
 
-impl ReplicationDiagnosticsPlugin {
+impl ClientDiagnosticsPlugin {
     /// How many entities modified per second by replication
     pub const ENTITY_CHANGES: DiagnosticId =
         DiagnosticId::from_u128(87359945710349305342211647237348);

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -6,137 +6,128 @@ use bevy::{
 };
 use std::time::Duration;
 
-/// Collects replication stats during packet processing
-/// flushed to Diagnostics system periodically.
+/// Replication stats during packet processing.
+///
+/// Flushed to Diagnostics system periodically.
 #[derive(Default, Resource, Debug)]
 pub struct ReplicationStats {
-    // incremented per entity that changes
+    /// Incremented per entity that changes.
     pub entities_changed: u32,
-    // incremented for every component that changes
+    /// Incremented for every component that changes.
     pub components_changed: u32,
-    // incremented per client mapping added
+    /// Incremented per client mapping added.
     pub mappings: u32,
-    // incrementer per entity despawn
+    /// Incremented per entity despawn.
     pub despawns: u32,
-    // replication packets recvd
+    /// Replication packets received.
     pub packets: u32,
-    // replication bytes received as packet payload (not transport layer headers, etc)
+    /// Replication bytes received in packet payloads.
+    /// (not transport layer headers, etc)
     pub bytes: u32,
 }
 
-/// Diagnostic IDs for per-second replication diagnostics
-pub mod replication_diagnostics {
-    use super::*;
-    /// How many entities modified per second by replication
-    pub const REPLICATED_ENTITY_CHANGES_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(87359945710349305342211647237348);
-    /// How many components modified per second by replication
-    pub const REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(36575095059706152186806005753628);
-    /// How many client-mappings added per second by replication
-    pub const REPLICATED_MAPPINGS_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(61564098061172206743744706749187);
-    /// How many despawns per second from replication
-    pub const REPLICATED_DESPAWNS_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(11043323327351349675112378115868);
-    /// How many replication packets processed per second
-    pub const REPLICATED_PACKETS_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(40094818756895929689855772983865);
-    /// How many bytes of replication packets payloads per second
-    pub const REPLICATED_BYTES_DIAGNOSTIC: DiagnosticId =
-        DiagnosticId::from_u128(87998088176776397493423835383418);
-
-    /// Diagnostic max_history_length
-    pub const REPLICATED_DIAGNOSTIC_HISTORY_LEN: usize = 60;
-}
-
-use replication_diagnostics::*;
-
 /// Clientside plugin to write Diagnostics every second
 /// Not added by default.
-///
-/// See [`replication_diagnostics`]
 #[derive(Default)]
-pub(super) struct ReplicationStatsPlugin;
+pub struct ReplicationDiagnosticsPlugin;
 
-impl Plugin for ReplicationStatsPlugin {
+impl Plugin for ReplicationDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         let diagnostics_timer = Duration::from_millis(1000);
         app.add_systems(
             Update,
-            write_diagnostics.run_if(on_timer(diagnostics_timer)),
+            Self::diagnostic_system.run_if(on_timer(diagnostics_timer)),
         )
         .init_resource::<ReplicationStats>()
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_ENTITY_CHANGES_DIAGNOSTIC,
+            Self::ENTITY_CHANGES,
             "entities changed per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ))
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC,
+            Self::COMPONENT_CHANGES,
             "components changed per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ))
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_MAPPINGS_DIAGNOSTIC,
+            Self::MAPPINGS,
             "mappings added per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ))
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_DESPAWNS_DIAGNOSTIC,
+            Self::DESPAWNS,
             "despawns per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ))
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_PACKETS_DIAGNOSTIC,
+            Self::PACKETS,
             "packets per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ))
         .register_diagnostic(Diagnostic::new(
-            REPLICATED_BYTES_DIAGNOSTIC,
+            Self::BYTES,
             "bytes per second",
-            REPLICATED_DIAGNOSTIC_HISTORY_LEN,
+            Self::DIAGNOSTIC_HISTORY_LEN,
         ));
     }
 }
 
-/// flushes aggregated stats to diagnostics system
-fn write_diagnostics(mut stats: ResMut<ReplicationStats>, mut diagnostics: Diagnostics) {
-    diagnostics.add_measurement(REPLICATED_ENTITY_CHANGES_DIAGNOSTIC, || {
-        if stats.packets == 0 {
-            0_f64
-        } else {
-            stats.entities_changed as f64 / stats.packets as f64
-        }
-    });
-    diagnostics.add_measurement(REPLICATED_COMPONENT_CHANGES_DIAGNOSTIC, || {
-        if stats.packets == 0 {
-            0_f64
-        } else {
-            stats.components_changed as f64 / stats.packets as f64
-        }
-    });
-    diagnostics.add_measurement(REPLICATED_MAPPINGS_DIAGNOSTIC, || {
-        if stats.packets == 0 {
-            0_f64
-        } else {
-            stats.mappings as f64 / stats.packets as f64
-        }
-    });
-    diagnostics.add_measurement(REPLICATED_DESPAWNS_DIAGNOSTIC, || {
-        if stats.packets == 0 {
-            0_f64
-        } else {
-            stats.despawns as f64 / stats.packets as f64
-        }
-    });
-    diagnostics.add_measurement(REPLICATED_BYTES_DIAGNOSTIC, || {
-        if stats.packets == 0 {
-            0_f64
-        } else {
-            stats.bytes as f64 / stats.packets as f64
-        }
-    });
-    diagnostics.add_measurement(REPLICATED_PACKETS_DIAGNOSTIC, || stats.packets as f64);
-    *stats = ReplicationStats::default();
+impl ReplicationDiagnosticsPlugin {
+    /// How many entities modified per second by replication
+    pub const ENTITY_CHANGES: DiagnosticId =
+        DiagnosticId::from_u128(87359945710349305342211647237348);
+    /// How many components modified per second by replication
+    pub const COMPONENT_CHANGES: DiagnosticId =
+        DiagnosticId::from_u128(36575095059706152186806005753628);
+    /// How many client-mappings added per second by replication
+    pub const MAPPINGS: DiagnosticId = DiagnosticId::from_u128(61564098061172206743744706749187);
+    /// How many despawns per second from replication
+    pub const DESPAWNS: DiagnosticId = DiagnosticId::from_u128(11043323327351349675112378115868);
+    /// How many replication packets processed per second
+    pub const PACKETS: DiagnosticId = DiagnosticId::from_u128(40094818756895929689855772983865);
+    /// How many bytes of replication packets payloads per second
+    pub const BYTES: DiagnosticId = DiagnosticId::from_u128(87998088176776397493423835383418);
+
+    /// Diagnostic max_history_length
+    pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
+
+    fn diagnostic_system(mut stats: ResMut<ReplicationStats>, mut diagnostics: Diagnostics) {
+        diagnostics.add_measurement(Self::ENTITY_CHANGES, || {
+            if stats.packets == 0 {
+                0_f64
+            } else {
+                stats.entities_changed as f64 / stats.packets as f64
+            }
+        });
+        diagnostics.add_measurement(Self::COMPONENT_CHANGES, || {
+            if stats.packets == 0 {
+                0_f64
+            } else {
+                stats.components_changed as f64 / stats.packets as f64
+            }
+        });
+        diagnostics.add_measurement(Self::MAPPINGS, || {
+            if stats.packets == 0 {
+                0_f64
+            } else {
+                stats.mappings as f64 / stats.packets as f64
+            }
+        });
+        diagnostics.add_measurement(Self::DESPAWNS, || {
+            if stats.packets == 0 {
+                0_f64
+            } else {
+                stats.despawns as f64 / stats.packets as f64
+            }
+        });
+        diagnostics.add_measurement(Self::BYTES, || {
+            if stats.packets == 0 {
+                0_f64
+            } else {
+                stats.bytes as f64 / stats.packets as f64
+            }
+        });
+        diagnostics.add_measurement(Self::PACKETS, || stats.packets as f64);
+        *stats = ReplicationStats::default();
+    }
 }

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -28,7 +28,6 @@ pub struct ClientStats {
 /// Plugin to write Diagnostics every second.
 ///
 /// Not added by default.
-#[derive(Default)]
 pub struct ClientDiagnosticsPlugin;
 
 impl Plugin for ClientDiagnosticsPlugin {

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -32,10 +32,9 @@ pub struct ClientDiagnosticsPlugin;
 
 impl Plugin for ClientDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        let diagnostics_timer = Duration::from_millis(1000);
         app.add_systems(
             Update,
-            Self::diagnostic_system.run_if(on_timer(diagnostics_timer)),
+            Self::diagnostic_system.run_if(on_timer(Duration::from_secs(1))),
         )
         .init_resource::<ClientStats>()
         .register_diagnostic(Diagnostic::new(

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -23,7 +23,7 @@ pub struct ClientStats {
     pub packets: u32,
     /// Replication bytes received in packet payloads.
     /// (not transport layer headers, etc)
-    pub bytes: u32,
+    pub bytes: u64,
 }
 
 /// Plugin to write Diagnostics every second.

--- a/src/client/diagnostics.rs
+++ b/src/client/diagnostics.rs
@@ -21,12 +21,12 @@ pub struct ClientStats {
     pub despawns: u32,
     /// Replication packets received.
     pub packets: u32,
-    /// Replication bytes received in packet payloads.
-    /// (not transport layer headers, etc)
+    /// Replication bytes received in packet payloads (without internal Renet data).
     pub bytes: u64,
 }
 
 /// Plugin to write Diagnostics every second.
+///
 /// Not added by default.
 #[derive(Default)]
 pub struct ClientDiagnosticsPlugin;
@@ -73,22 +73,22 @@ impl Plugin for ClientDiagnosticsPlugin {
 }
 
 impl ClientDiagnosticsPlugin {
-    /// How many entities modified per second by replication
+    /// How many entities modified per second by replication.
     pub const ENTITY_CHANGES: DiagnosticId =
         DiagnosticId::from_u128(87359945710349305342211647237348);
-    /// How many components modified per second by replication
+    /// How many components modified per second by replication.
     pub const COMPONENT_CHANGES: DiagnosticId =
         DiagnosticId::from_u128(36575095059706152186806005753628);
-    /// How many client-mappings added per second by replication
+    /// How many client-mappings added per second by replication.
     pub const MAPPINGS: DiagnosticId = DiagnosticId::from_u128(61564098061172206743744706749187);
-    /// How many despawns per second from replication
+    /// How many despawns per second from replication.
     pub const DESPAWNS: DiagnosticId = DiagnosticId::from_u128(11043323327351349675112378115868);
-    /// How many replication packets processed per second
+    /// How many replication packets processed per second.
     pub const PACKETS: DiagnosticId = DiagnosticId::from_u128(40094818756895929689855772983865);
-    /// How many bytes of replication packets payloads per second
+    /// How many bytes of replication packets payloads per second.
     pub const BYTES: DiagnosticId = DiagnosticId::from_u128(87998088176776397493423835383418);
 
-    /// Diagnostic max_history_length
+    /// Max diagnostic history length.
     pub const DIAGNOSTIC_HISTORY_LEN: usize = 60;
 
     fn diagnostic_system(mut stats: ResMut<ClientStats>, mut diagnostics: Diagnostics) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,8 +390,10 @@ pub mod server;
 
 pub mod prelude {
     pub use super::{
-        client::diagnostics::{ReplicationDiagnosticsPlugin, ReplicationStats},
-        client::{ClientMapper, ClientPlugin, ClientSet, LastRepliconTick, ServerEntityMap},
+        client::{
+            ClientDiagnosticsPlugin, ClientMapper, ClientPlugin, ClientSet, LastRepliconTick,
+            ReplicationStats, ServerEntityMap,
+        },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},
             server_event::{SendMode, ServerEventAppExt, ToClients},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,8 +391,8 @@ pub mod server;
 pub mod prelude {
     pub use super::{
         client::{
-            ClientDiagnosticsPlugin, ClientMapper, ClientPlugin, ClientSet, ClientStats,
-            LastRepliconTick, ServerEntityMap,
+            diagnostics::{ClientDiagnosticsPlugin, ClientStats},
+            ClientMapper, ClientPlugin, ClientSet, LastRepliconTick, ServerEntityMap,
         },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,8 +391,8 @@ pub mod server;
 pub mod prelude {
     pub use super::{
         client::{
-            ClientDiagnosticsPlugin, ClientMapper, ClientPlugin, ClientSet, LastRepliconTick,
-            ReplicationStats, ServerEntityMap,
+            ClientDiagnosticsPlugin, ClientMapper, ClientPlugin, ClientSet, ClientStats,
+            LastRepliconTick, ServerEntityMap,
         },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,6 +390,7 @@ pub mod server;
 
 pub mod prelude {
     pub use super::{
+        client::diagnostics::replication_diagnostics as ReplicationDiagnostics,
         client::{ClientMapper, ClientPlugin, ClientSet, LastRepliconTick, ServerEntityMap},
         network_event::{
             client_event::{ClientEventAppExt, FromClient},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ pub mod server;
 
 pub mod prelude {
     pub use super::{
-        client::diagnostics::replication_diagnostics as ReplicationDiagnostics,
+        client::diagnostics::{ReplicationDiagnosticsPlugin, ReplicationStats},
         client::{ClientMapper, ClientPlugin, ClientSet, LastRepliconTick, ServerEntityMap},
         network_event::{
             client_event::{ClientEventAppExt, FromClient},


### PR DESCRIPTION
Aggregates a few stats while processing packets, and flushes them to bevy's Diagnostics system every second.

I like the [ScreenDiagnosticsPlugin](https://github.com/laundmo/bevy_screen_diagnostics) for quickly displaying various diagnostics. I have it set up like this:

```rust
use bevy_replicon::prelude::ReplicationDiagnostics::*;

app
  .add_plugins(ScreenDiagnosticsPlugin::default())
  .add_plugins(ClientDiagnosticsPlugin)
  .add_systems(Startup, setup_replicon_diagnostics);

// app.add_plugins(ScreenDiagnosticsPlugin::default())
fn setup_replicon_diagnostics(mut diags: ResMut<ScreenDiagnostics>) {
    diags
        .add(
            "r:c/s".to_string(),
            ClientDiagnosticsPlugin::COMPONENT_CHANGES,
        )
        .format(|v| format!("{v:.1}"));

    diags
        .add("r:e/s".to_string(), ClientDiagnosticsPlugin::ENTITY_CHANGES)
        .format(|v| format!("{v:.1}"));

    diags
        .add("r:p/s".to_string(), ClientDiagnosticsPlugin::PACKETS)
        .format(|v| format!("{v:.0}"));

    diags
        .add("r:b/s".to_string(), ClientDiagnosticsPlugin::BYTES)
        .format(|v| format!("{v:.0}"));
}
```


https://github.com/lifescapegame/bevy_replicon/assets/29747/d22445d5-491e-4de2-9085-9abd6b72f798



