### PR TITLE
Rename `reflect` event registration methods into `seed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Optimize despawn tracking.
+- Rename `reflect` event registration methods into `seed`. This is more correct because it can be used not only for reflection.
 
 ## [0.14.0] - 2023-10-05
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,12 +280,12 @@ impl MapNetworkEntities for MappedEvent {
 }
 ```
 
-There is also [`ClientEventAppExt::add_client_reflect_event()`] and [`ClientEventAppExt::add_mapped_client_reflect_event()`]
-for events that require reflection for serialization and deserialization (for example, events that contain `Box<dyn Reflect>`).
+There is also [`ClientEventAppExt::add_client_event_seed()`] and [`ClientEventAppExt::add_mapped_client_event_seed()`]
+for events that implements deserialization via `DeserializeSeed`. This could be usedul for events contain `Box<dyn Reflect>`.
 To serialize such event you need to write serializer and deserializer manually because for such types you need access to `AppTypeRegistry`.
 It's pretty straigtforward but requires some boilerplate. See [`BuildEventSerializer`], [`BuildEventDeserializer`] and module
 `common` module in integration tests as example.
-Don't forget to check what inside every `Box<dyn Reflect>` from a client, it could be anything!
+Don't forget to validate what inside every `Box<dyn Reflect>` from a client, it could be anything!
 
 ### From server to client
 
@@ -325,7 +325,7 @@ struct DummyEvent;
 Just like with client events, if the event contains an entity, then
 [`ServerEventAppExt::add_mapped_server_event()`] should be used instead.
 
-And for events with `Box<dyn Reflect>` you can use [`ServerEventAppExt::add_server_reflect_event()`] and [`ServerEventAppExt::add_mapped_server_reflect_event()`].
+And for events that use `DeserializeSeed` you can use [`ServerEventAppExt::add_server_event_seed()`] and [`ServerEventAppExt::add_mapped_server_event_seed()`].
 
 ## Server and client creation
 

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -38,8 +38,9 @@ pub trait ClientEventAppExt {
     /// Same as [`Self::add_client_event`], but the event will be serialized/deserialized using `S`/`D`
     /// with access to [`AppTypeRegistry`].
     ///
-    /// Needed to send events that contain things like `Box<dyn Reflect>`.
-    fn add_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    /// Needed to send events that implements deserialization via `DeserializeSeed`.
+    /// Could be used for sending events with `Box<dyn Reflect>`.
+    fn add_client_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug,
         S: BuildEventSerializer<T> + 'static,
@@ -47,11 +48,8 @@ pub trait ClientEventAppExt {
         for<'a> S::EventSerializer<'a>: Serialize,
         for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
 
-    /// Same as [`Self::add_client_reflect_event`], but additionally maps client entities to server before sending.
-    fn add_mapped_client_reflect_event<T, S, D>(
-        &mut self,
-        policy: impl Into<SendType>,
-    ) -> &mut Self
+    /// Same as [`Self::add_client_event_seed`], but additionally maps client entities to server before sending.
+    fn add_mapped_client_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug + MapNetworkEntities,
         S: BuildEventSerializer<T> + 'static,
@@ -89,7 +87,7 @@ impl ClientEventAppExt for App {
         )
     }
 
-    fn add_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    fn add_client_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug,
         S: BuildEventSerializer<T> + 'static,
@@ -99,12 +97,12 @@ impl ClientEventAppExt for App {
     {
         self.add_client_event_with::<T, _, _>(
             policy,
-            sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
+            sending_seed_system::<T, S>,
+            receiving_seed_system::<T, D>,
         )
     }
 
-    fn add_mapped_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    fn add_mapped_client_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug + MapNetworkEntities,
         S: BuildEventSerializer<T> + 'static,
@@ -114,8 +112,8 @@ impl ClientEventAppExt for App {
     {
         self.add_client_event_with::<T, _, _>(
             policy,
-            mapping_and_sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
+            mapping_and_sending_seed_system::<T, S>,
+            receiving_seed_system::<T, D>,
         )
     }
 
@@ -171,7 +169,7 @@ fn receiving_system<T: Event + DeserializeOwned + Debug>(
     }
 }
 
-fn receiving_reflect_system<T, D>(
+fn receiving_seed_system<T, D>(
     mut client_events: EventWriter<FromClient<T>>,
     mut server: ResMut<RenetServer>,
     channel: Res<EventChannel<T>>,
@@ -188,11 +186,11 @@ fn receiving_reflect_system<T, D>(
                 bincode::Deserializer::from_slice(&message, DefaultOptions::new());
             match D::new(&registry).deserialize(&mut deserializer) {
                 Ok(event) => {
-                    debug!("received reflect event {event:?} from client {client_id}");
+                    debug!("received event {event:?} from client {client_id}");
                     client_events.send(FromClient { client_id, event });
                 }
                 Err(e) => {
-                    error!("unable to deserialize reflect event from client {client_id}: {e}")
+                    error!("unable to deserialize event from client {client_id}: {e}")
                 }
             }
         }
@@ -229,7 +227,7 @@ fn mapping_and_sending_system<T: Event + MapNetworkEntities + Serialize + Debug>
     }
 }
 
-fn sending_reflect_system<T, S>(
+fn sending_seed_system<T, S>(
     mut events: EventReader<T>,
     mut client: ResMut<RenetClient>,
     channel: Res<EventChannel<T>>,
@@ -244,13 +242,13 @@ fn sending_reflect_system<T, S>(
         let serializer = S::new(event, &registry);
         let message = DefaultOptions::new()
             .serialize(&serializer)
-            .expect("client reflect event should be serializable");
+            .expect("client event should be serializable");
         client.send_message(channel.id, message);
-        debug!("sent client reflect event {event:?}");
+        debug!("sent client event {event:?}");
     }
 }
 
-fn mapping_and_sending_reflect_system<T, S>(
+fn mapping_and_sending_seed_system<T, S>(
     mut events: ResMut<Events<T>>,
     mut client: ResMut<RenetClient>,
     entity_map: Res<ServerEntityMap>,
@@ -267,9 +265,9 @@ fn mapping_and_sending_reflect_system<T, S>(
         let serializer = S::new(&event, &registry);
         let message = DefaultOptions::new()
             .serialize(&serializer)
-            .expect("mapped client reflect event should be serializable");
+            .expect("mapped client event should be serializable");
         client.send_message(channel.id, message);
-        debug!("sent mapped client reflect event {event:?}");
+        debug!("sent mapped client event {event:?}");
     }
 }
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -38,8 +38,9 @@ pub trait ServerEventAppExt {
     /// Same as [`Self::add_server_event`], but the event will be serialized/deserialized using `S`/`D`
     /// with access to [`AppTypeRegistry`].
     ///
-    /// Needed to send events that contain things like `Box<dyn Reflect>`.
-    fn add_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    /// Needed to send events that implements deserialization via `DeserializeSeed`.
+    /// Could be used for sending events with `Box<dyn Reflect>`.
+    fn add_server_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug,
         S: BuildEventSerializer<T> + 'static,
@@ -47,11 +48,8 @@ pub trait ServerEventAppExt {
         for<'a> S::EventSerializer<'a>: Serialize,
         for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
 
-    /// Same as [`Self::add_server_reflect_event`], but additionally maps client entities to client after receiving.
-    fn add_mapped_server_reflect_event<T, S, D>(
-        &mut self,
-        policy: impl Into<SendType>,
-    ) -> &mut Self
+    /// Same as [`Self::add_server_event_seed`], but additionally maps client entities to client after receiving.
+    fn add_mapped_server_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug + MapNetworkEntities,
         S: BuildEventSerializer<T> + 'static,
@@ -89,7 +87,7 @@ impl ServerEventAppExt for App {
         )
     }
 
-    fn add_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    fn add_server_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug,
         S: BuildEventSerializer<T> + 'static,
@@ -99,12 +97,12 @@ impl ServerEventAppExt for App {
     {
         self.add_server_event_with::<T, _, _>(
             policy,
-            sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
+            sending_seed_system::<T, S>,
+            receiving_seed_system::<T, D>,
         )
     }
 
-    fn add_mapped_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
+    fn add_mapped_server_event_seed<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
     where
         T: Event + Debug + MapNetworkEntities,
         S: BuildEventSerializer<T> + 'static,
@@ -114,8 +112,8 @@ impl ServerEventAppExt for App {
     {
         self.add_server_event_with::<T, _, _>(
             policy,
-            sending_reflect_system::<T, S>,
-            receiving_and_mapping_reflect_system::<T, D>,
+            sending_seed_system::<T, S>,
+            receiving_and_mapping_seed_system::<T, D>,
         )
     }
 
@@ -183,7 +181,7 @@ fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned
     }
 }
 
-fn receiving_reflect_system<T, D>(
+fn receiving_seed_system<T, D>(
     mut server_events: EventWriter<T>,
     mut client: ResMut<RenetClient>,
     channel: Res<EventChannel<T>>,
@@ -198,13 +196,13 @@ fn receiving_reflect_system<T, D>(
         let mut deserializer = bincode::Deserializer::from_slice(&message, DefaultOptions::new());
         let event = D::new(&registry)
             .deserialize(&mut deserializer)
-            .expect("server should send valid reflect events");
-        debug!("received reflect event {event:?} from server");
+            .expect("server should send valid events");
+        debug!("received event {event:?} from server");
         server_events.send(event);
     }
 }
 
-fn receiving_and_mapping_reflect_system<T, D>(
+fn receiving_and_mapping_seed_system<T, D>(
     mut server_events: EventWriter<T>,
     mut client: ResMut<RenetClient>,
     entity_map: Res<ServerEntityMap>,
@@ -220,8 +218,8 @@ fn receiving_and_mapping_reflect_system<T, D>(
         let mut deserializer = bincode::Deserializer::from_slice(&message, DefaultOptions::new());
         let mut event = D::new(&registry)
             .deserialize(&mut deserializer)
-            .expect("server should send valid mapped reflect events");
-        debug!("received mapped reflect event {event:?} from server");
+            .expect("server should send valid mapped events");
+        debug!("received mapped event {event:?} from server");
         event.map_entities(&mut EventMapper(entity_map.to_client()));
         server_events.send(event);
     }
@@ -260,7 +258,7 @@ fn sending_system<T: Event + Serialize + Debug>(
     }
 }
 
-fn sending_reflect_system<T, S>(
+fn sending_seed_system<T, S>(
     mut server: ResMut<RenetServer>,
     mut server_events: EventReader<ToClients<T>>,
     channel: Res<EventChannel<T>>,
@@ -280,7 +278,7 @@ fn sending_reflect_system<T, S>(
         match *mode {
             SendMode::Broadcast => {
                 server.broadcast_message(channel.id, message);
-                debug!("broadcasted server reflect event {event:?}");
+                debug!("broadcasted server event {event:?}");
             }
             SendMode::BroadcastExcept(client_id) => {
                 if client_id == SERVER_ID {
@@ -288,12 +286,12 @@ fn sending_reflect_system<T, S>(
                 } else {
                     server.broadcast_message_except(client_id, channel.id, message);
                 }
-                debug!("broadcasted server reflect event {event:?} except client {client_id}");
+                debug!("broadcasted server event {event:?} except client {client_id}");
             }
             SendMode::Direct(client_id) => {
                 if client_id != SERVER_ID {
                     server.send_message(client_id, channel.id, message);
-                    debug!("sent direct server reflect event {event:?} to client {client_id}");
+                    debug!("sent direct server event {event:?} to client {client_id}");
                 }
             }
         }

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -87,13 +87,13 @@ fn mapping_and_sending_receiving() {
 }
 
 #[test]
-fn sending_receiving_reflect() {
+fn sending_receiving_seed() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
             .register_type::<ReflectedValue>()
-            .add_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
+            .add_client_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
                 SendPolicy::Ordered,
                 );
     }
@@ -118,13 +118,13 @@ fn sending_receiving_reflect() {
 }
 
 #[test]
-fn mapping_and_sending_receiving_reflect() {
+fn mapping_and_sending_receiving_seed() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
             .register_type::<ReflectedValue>()
-            .add_mapped_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
+            .add_mapped_client_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -114,7 +114,7 @@ fn sending_receiving_and_mapping() {
 }
 
 #[test]
-fn sending_receiving_reflect() {
+fn sending_receiving_seed() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -123,7 +123,7 @@ fn sending_receiving_reflect() {
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
         .register_type::<ReflectedValue>()
-        .add_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
+        .add_server_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
             SendPolicy::Ordered,
         );
     }
@@ -165,7 +165,7 @@ fn sending_receiving_reflect() {
 }
 
 #[test]
-fn sending_receiving_and_mapping_reflect() {
+fn sending_receiving_and_mapping_seed() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -174,7 +174,7 @@ fn sending_receiving_and_mapping_reflect() {
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
         .register_type::<ReflectedValue>()
-        .add_mapped_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
+        .add_mapped_server_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);


### PR DESCRIPTION
This is more correct because it can be used not only for reflection.