### PR TITLE
Revert "Rename reflect event registration methods into seed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Optimize despawn tracking.
-- Rename `reflect` event registration methods into `seed`. This is more correct because it can be used not only for reflection.
 
 ## [0.14.0] - 2023-10-05
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,8 @@ impl MapNetworkEntities for MappedEvent {
 }
 ```
 
-There is also [`ClientEventAppExt::add_client_event_seed()`] and [`ClientEventAppExt::add_mapped_client_event_seed()`]
-for events that implements deserialization via `DeserializeSeed`. This could be useful for events contain `Box<dyn Reflect>`.
+There is also [`ClientEventAppExt::add_client_reflect_event()`] and [`ClientEventAppExt::add_mapped_client_reflect_event()`]
+for events that require reflection for serialization and deserialization (for example, events that contain `Box<dyn Reflect>`).
 To serialize such event you need to write serializer and deserializer manually because for such types you need access to `AppTypeRegistry`.
 It's pretty straigtforward but requires some boilerplate. See [`BuildEventSerializer`], [`BuildEventDeserializer`] and module
 `common` module in integration tests as example.
@@ -325,7 +325,7 @@ struct DummyEvent;
 Just like with client events, if the event contains an entity, then
 [`ServerEventAppExt::add_mapped_server_event()`] should be used instead.
 
-And for events that use `DeserializeSeed` you can use [`ServerEventAppExt::add_server_event_seed()`] and [`ServerEventAppExt::add_mapped_server_event_seed()`].
+And for events with `Box<dyn Reflect>` you can use [`ServerEventAppExt::add_server_reflect_event()`] and [`ServerEventAppExt::add_mapped_server_reflect_event()`].
 
 ## Server and client creation
 

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -87,13 +87,13 @@ fn mapping_and_sending_receiving() {
 }
 
 #[test]
-fn sending_receiving_seed() {
+fn sending_receiving_reflect() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
             .register_type::<ReflectedValue>()
-            .add_client_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
+            .add_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
                 SendPolicy::Ordered,
                 );
     }
@@ -118,13 +118,13 @@ fn sending_receiving_seed() {
 }
 
 #[test]
-fn mapping_and_sending_receiving_seed() {
+fn mapping_and_sending_receiving_reflect() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
             .register_type::<ReflectedValue>()
-            .add_mapped_client_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
+            .add_mapped_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -114,7 +114,7 @@ fn sending_receiving_and_mapping() {
 }
 
 #[test]
-fn sending_receiving_seed() {
+fn sending_receiving_reflect() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -123,7 +123,7 @@ fn sending_receiving_seed() {
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
         .register_type::<ReflectedValue>()
-        .add_server_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
+        .add_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
             SendPolicy::Ordered,
         );
     }
@@ -165,7 +165,7 @@ fn sending_receiving_seed() {
 }
 
 #[test]
-fn sending_receiving_and_mapping_seed() {
+fn sending_receiving_and_mapping_reflect() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -174,7 +174,7 @@ fn sending_receiving_and_mapping_seed() {
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
         .register_type::<ReflectedValue>()
-        .add_mapped_server_event_seed::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
+        .add_mapped_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);


### PR DESCRIPTION
I realized that it accepts `TypeRegistry`, so it's actually useful only for reflection. I keep some comment improvements from this commit.