### PR TITLE
Remove special functions for reflect events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `network_event::server_event::send` helper for server events in custom sending functions.
 - Optional `ClientDiagnosticsPlugin`, which writes diagnostics every second.
 
 ### Changed
 
 - Optimize despawn tracking.
 - Hide `id` field in `EventChannel` and add `Clone` and `Copy` impls for it.
+- Remove special functions for reflect events and advice users to write them manually instead. It's even easier because sometime you can directly use reflect serializers from Bevy directly instead of manually writing serde traits.
+
+### Removed
+
+- `Debug` requirement for events.
 
 ## [0.14.0] - 2023-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Optimize despawn tracking.
 - Hide `id` field in `EventChannel` and add `Clone` and `Copy` impls for it.
-- Remove special functions for reflect events and advice users to write them manually instead. It's even easier because sometime you can directly use reflect serializers from Bevy directly instead of manually writing serde traits.
+- Remove special functions for reflect events and advise users to write them manually instead. Reflect events are easier now because sometimes you can directly use reflect serializers from Bevy instead of manually writing serde traits.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ bevy_renet = "0.0.9"
 bevy = { version = "0.11", default-features = false, features = ["bevy_scene"] }
 bincode = "1.3"
 serde = "1.0"
-strum = { version = "0.25", features = ["derive"] }
 varint-rs = "2.2"
 
 [dev-dependencies]

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -219,7 +219,7 @@ impl SimpleBoxPlugin {
 const PORT: u16 = 5000;
 const PROTOCOL_ID: u64 = 0;
 
-#[derive(Debug, Parser, PartialEq, Resource)]
+#[derive(Parser, PartialEq, Resource)]
 enum Cli {
     SinglePlayer,
     Server {

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -2,6 +2,7 @@
 //! Run it with `--hotseat` to play locally or with `--client` / `--server`
 
 use std::{
+    fmt::{self, Formatter},
     net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
     time::SystemTime,
 };
@@ -21,7 +22,6 @@ use bevy_replicon::{
 };
 use clap::{Parser, ValueEnum};
 use serde::{Deserialize, Serialize};
-use strum::Display;
 
 fn main() {
     App::new()
@@ -584,10 +584,7 @@ enum GameState {
 struct CurrentTurn(Symbol);
 
 /// A component that defines the symbol of a player or a filled cell.
-#[derive(
-    Clone, Component, Copy, Default, Deserialize, Display, Eq, PartialEq, Serialize, ValueEnum,
-)]
-#[strum(serialize_all = "kebab-case")]
+#[derive(Clone, Component, Copy, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 enum Symbol {
     #[default]
     Cross,
@@ -613,6 +610,15 @@ impl Symbol {
         match self {
             Symbol::Cross => Symbol::Nought,
             Symbol::Nought => Symbol::Cross,
+        }
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Symbol::Cross => f.write_str("cross"),
+            Symbol::Nought => f.write_str("nought"),
         }
     }
 }

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -533,7 +533,7 @@ fn any_component_added<T: Component>() -> impl FnMut(Query<(), Added<T>>) -> boo
 
 const PORT: u16 = 5000;
 
-#[derive(Debug, Parser, PartialEq, Resource)]
+#[derive(Parser, PartialEq, Resource)]
 enum Cli {
     Hotseat,
     Server {
@@ -585,17 +585,7 @@ struct CurrentTurn(Symbol);
 
 /// A component that defines the symbol of a player or a filled cell.
 #[derive(
-    Clone,
-    Component,
-    Copy,
-    Debug,
-    Default,
-    Deserialize,
-    Display,
-    Eq,
-    PartialEq,
-    Serialize,
-    ValueEnum,
+    Clone, Component, Copy, Default, Deserialize, Display, Eq, PartialEq, Serialize, ValueEnum,
 )]
 #[strum(serialize_all = "kebab-case")]
 enum Symbol {

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -676,5 +676,5 @@ struct Player(u64);
 ///
 /// We don't replicate the whole UI, so we can't just send the picked entity because on server it may be different.
 /// So we send the cell location in grid and calculate the entity on server based on this.
-#[derive(Clone, Copy, Debug, Deserialize, Event, Serialize)]
+#[derive(Clone, Copy, Deserialize, Event, Serialize)]
 struct CellPick(usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,8 +280,8 @@ impl MapNetworkEntities for MappedEvent {
 }
 ```
 
-There is also [`ClientEventAppExt::add_client_event_with()`] to to register an event with special sending and receiving function.
-This could be used for sending events that contain `Box<dyn Reflect>` because it requires access to `AppTypeRegistry` resource.
+There is also [`ClientEventAppExt::add_client_event_with()`] to register an event with special sending and receiving functions.
+This could be used for sending events that contain `Box<dyn Reflect>`, which require access to the `AppTypeRegistry` resource.
 Don't forget to validate the contents of every `Box<dyn Reflect>` from a client, it could be anything!
 
 ### From server to client
@@ -322,7 +322,7 @@ struct DummyEvent;
 Just like with client events, if the event contains an entity, then
 [`ServerEventAppExt::add_mapped_server_event()`] should be used instead.
 
-And for events that require special sending and receiving function you can use [`ServerEventAppExt::add_server_event_with()`].
+For events that require special sending and receiving functions you can use [`ServerEventAppExt::add_server_event_with()`].
 
 ## Server and client creation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,11 +280,8 @@ impl MapNetworkEntities for MappedEvent {
 }
 ```
 
-There is also [`ClientEventAppExt::add_client_reflect_event()`] and [`ClientEventAppExt::add_mapped_client_reflect_event()`]
-for events that require reflection for serialization and deserialization (for example, events that contain `Box<dyn Reflect>`).
-To serialize such event you need to write serializer and deserializer manually because for such types you need access to `AppTypeRegistry`.
-It's pretty straigtforward but requires some boilerplate. See [`BuildEventSerializer`], [`BuildEventDeserializer`] and module
-`common` module in integration tests as example.
+There is also [`ClientEventAppExt::add_client_event_with()`] to to register an event with special sending and receiving function.
+This could be used for sending events that contain `Box<dyn Reflect>` because it requires access to `AppTypeRegistry` resource.
 Don't forget to validate the contents of every `Box<dyn Reflect>` from a client, it could be anything!
 
 ### From server to client
@@ -325,7 +322,7 @@ struct DummyEvent;
 Just like with client events, if the event contains an entity, then
 [`ServerEventAppExt::add_mapped_server_event()`] should be used instead.
 
-And for events with `Box<dyn Reflect>` you can use [`ServerEventAppExt::add_server_reflect_event()`] and [`ServerEventAppExt::add_mapped_server_reflect_event()`].
+And for events that require special sending and receiving function you can use [`ServerEventAppExt::add_server_event_with()`].
 
 ## Server and client creation
 
@@ -397,7 +394,7 @@ pub mod prelude {
         network_event::{
             client_event::{ClientEventAppExt, FromClient},
             server_event::{SendMode, ServerEventAppExt, ToClients},
-            BuildEventDeserializer, BuildEventSerializer, EventMapper, SendPolicy,
+            EventChannel, EventMapper, SendPolicy,
         },
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},

--- a/src/network_event.rs
+++ b/src/network_event.rs
@@ -3,7 +3,7 @@ pub mod server_event;
 
 use std::{marker::PhantomData, time::Duration};
 
-use bevy::{prelude::*, reflect::TypeRegistryInternal, utils::HashMap};
+use bevy::{prelude::*, utils::HashMap};
 use bevy_renet::renet::SendType;
 
 use crate::replicon_core::replication_rules::Mapper;
@@ -36,22 +36,6 @@ impl<T> From<EventChannel<T>> for u8 {
     fn from(value: EventChannel<T>) -> Self {
         value.id
     }
-}
-
-/// Creates a struct implements serialization for the event using [`TypeRegistryInternal`].
-pub trait BuildEventSerializer<T> {
-    type EventSerializer<'a>
-    where
-        T: 'a;
-
-    fn new<'a>(event: &'a T, registry: &'a TypeRegistryInternal) -> Self::EventSerializer<'a>;
-}
-
-/// Creates a struct implements deserialization for the event using [`TypeRegistryInternal`].
-pub trait BuildEventDeserializer {
-    type EventDeserializer<'a>;
-
-    fn new(registry: &TypeRegistryInternal) -> Self::EventDeserializer<'_>;
 }
 
 /// Event delivery guarantee.

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -1,17 +1,12 @@
-use std::fmt::Debug;
-
 use bevy::{ecs::event::Event, prelude::*};
 use bevy_renet::{
     renet::{RenetClient, RenetServer, SendType},
     transport::client_connected,
 };
 use bincode::{DefaultOptions, Options};
-use serde::{
-    de::{DeserializeOwned, DeserializeSeed},
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Serialize};
 
-use super::{BuildEventDeserializer, BuildEventSerializer, EventChannel};
+use super::EventChannel;
 use crate::{
     client::{ClientSet, ServerEntityMap},
     network_event::EventMapper,
@@ -22,45 +17,88 @@ use crate::{
 /// An extension trait for [`App`] for creating client events.
 pub trait ClientEventAppExt {
     /// Registers [`FromClient<T>`] event that will be emitted on server after sending `T` event on client.
-    fn add_client_event<T: Event + Serialize + DeserializeOwned + Debug>(
+    fn add_client_event<T: Event + Serialize + DeserializeOwned>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self;
 
     /// Same as [`Self::add_client_event`], but additionally maps client entities to server before sending.
-    fn add_mapped_client_event<
-        T: Event + Serialize + DeserializeOwned + Debug + MapNetworkEntities,
-    >(
+    fn add_mapped_client_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self;
 
-    /// Same as [`Self::add_client_event`], but the event will be serialized/deserialized using `S`/`D`
-    /// with access to [`AppTypeRegistry`].
-    ///
-    /// Needed to send events that contain things like `Box<dyn Reflect>`.
-    fn add_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
+    /**
+    Same as [`Self::add_client_event`], but uses specified sending and receiving systems.
 
-    /// Same as [`Self::add_client_reflect_event`], but additionally maps client entities to server before sending.
-    fn add_mapped_client_reflect_event<T, S, D>(
-        &mut self,
-        policy: impl Into<SendType>,
-    ) -> &mut Self
-    where
-        T: Event + Debug + MapNetworkEntities,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
+    It's advised to not panic in receiving system because it runs on server.
 
-    /// Same as [`Self::add_client_event`], but uses specified sending and receiving systems.
-    fn add_client_event_with<T: Event + Debug, Marker1, Marker2>(
+    # Examples
+
+    Serialize an event with `Box<dyn Reflect>`:
+
+    ```
+    use bevy::{prelude::*, reflect::serde::{ReflectSerializer, UntypedReflectDeserializer}};
+    use bevy_replicon::prelude::*;
+    use bincode::{DefaultOptions, Options};
+    use serde::de::DeserializeSeed;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, ReplicationPlugins));
+    app.add_client_event_with::<ReflectEvent, _, _>(
+        SendPolicy::Ordered,
+        sending_reflect_system,
+        receiving_reflect_system,
+    );
+
+    fn sending_reflect_system(
+        mut events: EventReader<ReflectEvent>,
+        mut client: ResMut<RenetClient>,
+        channel: Res<EventChannel<ReflectEvent>>,
+        registry: Res<AppTypeRegistry>,
+    ) {
+        let registry = registry.read();
+        for event in &mut events {
+            let serializer = ReflectSerializer::new(&*event.0, &registry);
+            let message = DefaultOptions::new()
+                .serialize(&serializer)
+                .expect("client reflect event should be serializable");
+
+            client.send_message(*channel, message);
+        }
+    }
+
+    fn receiving_reflect_system(
+        mut client_events: EventWriter<FromClient<ReflectEvent>>,
+        mut server: ResMut<RenetServer>,
+        channel: Res<EventChannel<ReflectEvent>>,
+        registry: Res<AppTypeRegistry>,
+    ) {
+        let registry = registry.read();
+        for client_id in server.clients_id() {
+            while let Some(message) = server.receive_message(client_id, *channel) {
+                let mut deserializer =
+                    bincode::Deserializer::from_slice(&message, DefaultOptions::new());
+                match UntypedReflectDeserializer::new(&registry).deserialize(&mut deserializer) {
+                    Ok(reflect) => {
+                        client_events.send(FromClient {
+                            client_id,
+                            event: ReflectEvent(reflect),
+                        });
+                    }
+                    Err(e) => {
+                        error!("unable to deserialize reflect event from client {client_id}: {e}")
+                    }
+                }
+            }
+        }
+    }
+
+    #[derive(Event)]
+    struct ReflectEvent(Box<dyn Reflect>);
+    ```
+    */
+    fn add_client_event_with<T: Event, Marker1, Marker2>(
         &mut self,
         policy: impl Into<SendType>,
         sending_system: impl IntoSystemConfigs<Marker1>,
@@ -69,16 +107,14 @@ pub trait ClientEventAppExt {
 }
 
 impl ClientEventAppExt for App {
-    fn add_client_event<T: Event + Serialize + DeserializeOwned + Debug>(
+    fn add_client_event<T: Event + Serialize + DeserializeOwned>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self {
         self.add_client_event_with::<T, _, _>(policy, sending_system::<T>, receiving_system::<T>)
     }
 
-    fn add_mapped_client_event<
-        T: Event + Serialize + DeserializeOwned + Debug + MapNetworkEntities,
-    >(
+    fn add_mapped_client_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self {
@@ -89,37 +125,7 @@ impl ClientEventAppExt for App {
         )
     }
 
-    fn add_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-    {
-        self.add_client_event_with::<T, _, _>(
-            policy,
-            sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
-        )
-    }
-
-    fn add_mapped_client_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug + MapNetworkEntities,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-    {
-        self.add_client_event_with::<T, _, _>(
-            policy,
-            mapping_and_sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
-        )
-    }
-
-    fn add_client_event_with<T: Event + Debug, Marker1, Marker2>(
+    fn add_client_event_with<T: Event, Marker1, Marker2>(
         &mut self,
         policy: impl Into<SendType>,
         sending_system: impl IntoSystemConfigs<Marker1>,
@@ -153,7 +159,7 @@ impl ClientEventAppExt for App {
     }
 }
 
-fn receiving_system<T: Event + DeserializeOwned + Debug>(
+fn receiving_system<T: Event + DeserializeOwned>(
     mut client_events: EventWriter<FromClient<T>>,
     mut server: ResMut<RenetServer>,
     channel: Res<EventChannel<T>>,
@@ -162,7 +168,6 @@ fn receiving_system<T: Event + DeserializeOwned + Debug>(
         while let Some(message) = server.receive_message(client_id, channel.id) {
             match DefaultOptions::new().deserialize(&message) {
                 Ok(event) => {
-                    debug!("received event {event:?} from client {client_id}");
                     client_events.send(FromClient { client_id, event });
                 }
                 Err(e) => error!("unable to deserialize event from client {client_id}: {e}"),
@@ -171,35 +176,7 @@ fn receiving_system<T: Event + DeserializeOwned + Debug>(
     }
 }
 
-fn receiving_reflect_system<T, D>(
-    mut client_events: EventWriter<FromClient<T>>,
-    mut server: ResMut<RenetServer>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + Debug,
-    D: BuildEventDeserializer,
-    for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-{
-    let registry = registry.read();
-    for client_id in server.clients_id() {
-        while let Some(message) = server.receive_message(client_id, channel.id) {
-            let mut deserializer =
-                bincode::Deserializer::from_slice(&message, DefaultOptions::new());
-            match D::new(&registry).deserialize(&mut deserializer) {
-                Ok(event) => {
-                    debug!("received reflect event {event:?} from client {client_id}");
-                    client_events.send(FromClient { client_id, event });
-                }
-                Err(e) => {
-                    error!("unable to deserialize reflect event from client {client_id}: {e}")
-                }
-            }
-        }
-    }
-}
-
-fn sending_system<T: Event + Serialize + Debug>(
+fn sending_system<T: Event + Serialize>(
     mut events: EventReader<T>,
     mut client: ResMut<RenetClient>,
     channel: Res<EventChannel<T>>,
@@ -208,12 +185,12 @@ fn sending_system<T: Event + Serialize + Debug>(
         let message = DefaultOptions::new()
             .serialize(&event)
             .expect("client event should be serializable");
+
         client.send_message(channel.id, message);
-        debug!("sent client event {event:?}");
     }
 }
 
-fn mapping_and_sending_system<T: Event + MapNetworkEntities + Serialize + Debug>(
+fn mapping_and_sending_system<T: Event + MapNetworkEntities + Serialize>(
     mut events: ResMut<Events<T>>,
     mut client: ResMut<RenetClient>,
     entity_map: Res<ServerEntityMap>,
@@ -224,63 +201,18 @@ fn mapping_and_sending_system<T: Event + MapNetworkEntities + Serialize + Debug>
         let message = DefaultOptions::new()
             .serialize(&event)
             .expect("mapped client event should be serializable");
-        client.send_message(channel.id, message);
-        debug!("sent mapped client event {event:?}");
-    }
-}
 
-fn sending_reflect_system<T, S>(
-    mut events: EventReader<T>,
-    mut client: ResMut<RenetClient>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + Debug,
-    S: BuildEventSerializer<T>,
-    for<'a> S::EventSerializer<'a>: Serialize,
-{
-    let registry = registry.read();
-    for event in &mut events {
-        let serializer = S::new(event, &registry);
-        let message = DefaultOptions::new()
-            .serialize(&serializer)
-            .expect("client reflect event should be serializable");
         client.send_message(channel.id, message);
-        debug!("sent client reflect event {event:?}");
-    }
-}
-
-fn mapping_and_sending_reflect_system<T, S>(
-    mut events: ResMut<Events<T>>,
-    mut client: ResMut<RenetClient>,
-    entity_map: Res<ServerEntityMap>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + MapNetworkEntities + Debug,
-    S: BuildEventSerializer<T>,
-    for<'a> S::EventSerializer<'a>: Serialize,
-{
-    let registry = registry.read();
-    for mut event in events.drain() {
-        event.map_entities(&mut EventMapper(entity_map.to_server()));
-        let serializer = S::new(&event, &registry);
-        let message = DefaultOptions::new()
-            .serialize(&serializer)
-            .expect("mapped client reflect event should be serializable");
-        client.send_message(channel.id, message);
-        debug!("sent mapped client reflect event {event:?}");
     }
 }
 
 /// Transforms `T` events into [`FromClient<T>`] events to "emulate"
 /// message sending for offline mode or when server is also a player
-fn local_resending_system<T: Event + Debug>(
+fn local_resending_system<T: Event>(
     mut events: ResMut<Events<T>>,
     mut client_events: EventWriter<FromClient<T>>,
 ) {
     for event in events.drain() {
-        debug!("converted client event {event:?} into a local");
         client_events.send(FromClient {
             client_id: SERVER_ID,
             event,

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -31,7 +31,7 @@ pub trait ClientEventAppExt {
     /**
     Same as [`Self::add_client_event`], but uses specified sending and receiving systems.
 
-    It's advised to not panic in receiving system because it runs on server.
+    It's advised to not panic in the receiving system because it runs on the server.
 
     # Examples
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -196,7 +196,7 @@ fn sending_system<T: Event + Serialize>(
 
 /// Sends serialized `message` to clients.
 ///
-/// Helper for custom sending system.
+/// Helper for custom sending systems.
 /// See also [`ServerEventAppExt::add_server_event_with`]
 pub fn send<T>(
     server: &mut RenetServer,

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -1,17 +1,12 @@
-use std::fmt::Debug;
-
 use bevy::{ecs::event::Event, prelude::*};
 use bevy_renet::{
     renet::{RenetClient, RenetServer, SendType},
     transport::client_connected,
 };
 use bincode::{DefaultOptions, Options};
-use serde::{
-    de::{DeserializeOwned, DeserializeSeed},
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Serialize};
 
-use super::{BuildEventDeserializer, BuildEventSerializer, EventChannel};
+use super::EventChannel;
 use crate::{
     client::{ClientSet, ServerEntityMap},
     network_event::EventMapper,
@@ -22,45 +17,79 @@ use crate::{
 /// An extension trait for [`App`] for creating server events.
 pub trait ServerEventAppExt {
     /// Registers event `T` that will be emitted on client after sending [`ToClients<T>`] on server.
-    fn add_server_event<T: Event + Serialize + DeserializeOwned + Debug>(
+    fn add_server_event<T: Event + Serialize + DeserializeOwned>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self;
 
     /// Same as [`Self::add_server_event`], but additionally maps server entities to client after receiving.
-    fn add_mapped_server_event<
-        T: Event + Serialize + DeserializeOwned + Debug + MapNetworkEntities,
-    >(
+    fn add_mapped_server_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self;
 
-    /// Same as [`Self::add_server_event`], but the event will be serialized/deserialized using `S`/`D`
-    /// with access to [`AppTypeRegistry`].
-    ///
-    /// Needed to send events that contain things like `Box<dyn Reflect>`.
-    fn add_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
+    /**
+    Same as [`Self::add_server_event`], but uses specified sending and receiving systems.
 
-    /// Same as [`Self::add_server_reflect_event`], but additionally maps client entities to client after receiving.
-    fn add_mapped_server_reflect_event<T, S, D>(
-        &mut self,
-        policy: impl Into<SendType>,
-    ) -> &mut Self
-    where
-        T: Event + Debug + MapNetworkEntities,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>;
+    It's advised to not panic in sending system because it runs on server.
 
-    /// Same as [`Self::add_server_event`], but uses specified sending and receiving systems.
-    fn add_server_event_with<T: Event + Debug, Marker1, Marker2>(
+    # Examples
+
+    Serialize an event with `Box<dyn Reflect>`:
+
+    ```
+    use bevy::{prelude::*, reflect::serde::{ReflectSerializer, UntypedReflectDeserializer}};
+    use bevy_replicon::{network_event::server_event, prelude::*};
+    use bincode::{DefaultOptions, Options};
+    use serde::de::DeserializeSeed;
+
+    let mut app = App::new();
+    app.add_plugins((MinimalPlugins, ReplicationPlugins));
+    app.add_server_event_with::<ReflectEvent, _, _>(
+        SendPolicy::Ordered,
+        sending_reflect_system,
+        receiving_reflect_system,
+    );
+
+    fn sending_reflect_system(
+        mut server: ResMut<RenetServer>,
+        mut server_events: EventReader<ToClients<ReflectEvent>>,
+        channel: Res<EventChannel<ReflectEvent>>,
+        registry: Res<AppTypeRegistry>,
+    ) {
+        let registry = registry.read();
+        for ToClients { event, mode } in &mut server_events {
+            let serializer = ReflectSerializer::new(&*event.0, &registry);
+            let message = DefaultOptions::new()
+                .serialize(&serializer)
+                .expect("server event should be serializable");
+
+            server_event::send(&mut server, *channel, *mode, message)
+        }
+    }
+
+    fn receiving_reflect_system(
+        mut server_events: EventWriter<ReflectEvent>,
+        mut client: ResMut<RenetClient>,
+        channel: Res<EventChannel<ReflectEvent>>,
+        registry: Res<AppTypeRegistry>,
+    ) {
+        let registry = registry.read();
+        while let Some(message) = client.receive_message(*channel) {
+            let mut deserializer = bincode::Deserializer::from_slice(&message, DefaultOptions::new());
+            let event = UntypedReflectDeserializer::new(&registry)
+                .deserialize(&mut deserializer)
+                .expect("server should send valid events");
+
+            server_events.send(ReflectEvent(event));
+        }
+    }
+
+    #[derive(Event)]
+    struct ReflectEvent(Box<dyn Reflect>);
+    ```
+    */
+    fn add_server_event_with<T: Event, Marker1, Marker2>(
         &mut self,
         policy: impl Into<SendType>,
         sending_system: impl IntoSystemConfigs<Marker1>,
@@ -69,16 +98,14 @@ pub trait ServerEventAppExt {
 }
 
 impl ServerEventAppExt for App {
-    fn add_server_event<T: Event + Serialize + DeserializeOwned + Debug>(
+    fn add_server_event<T: Event + Serialize + DeserializeOwned>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self {
         self.add_server_event_with::<T, _, _>(policy, sending_system::<T>, receiving_system::<T>)
     }
 
-    fn add_mapped_server_event<
-        T: Event + Serialize + DeserializeOwned + Debug + MapNetworkEntities,
-    >(
+    fn add_mapped_server_event<T: Event + Serialize + DeserializeOwned + MapNetworkEntities>(
         &mut self,
         policy: impl Into<SendType>,
     ) -> &mut Self {
@@ -89,37 +116,7 @@ impl ServerEventAppExt for App {
         )
     }
 
-    fn add_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-    {
-        self.add_server_event_with::<T, _, _>(
-            policy,
-            sending_reflect_system::<T, S>,
-            receiving_reflect_system::<T, D>,
-        )
-    }
-
-    fn add_mapped_server_reflect_event<T, S, D>(&mut self, policy: impl Into<SendType>) -> &mut Self
-    where
-        T: Event + Debug + MapNetworkEntities,
-        S: BuildEventSerializer<T> + 'static,
-        D: BuildEventDeserializer + 'static,
-        for<'a> S::EventSerializer<'a>: Serialize,
-        for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-    {
-        self.add_server_event_with::<T, _, _>(
-            policy,
-            sending_reflect_system::<T, S>,
-            receiving_and_mapping_reflect_system::<T, D>,
-        )
-    }
-
-    fn add_server_event_with<T: Event + Debug, Marker1, Marker2>(
+    fn add_server_event_with<T: Event, Marker1, Marker2>(
         &mut self,
         policy: impl Into<SendType>,
         sending_system: impl IntoSystemConfigs<Marker1>,
@@ -153,7 +150,7 @@ impl ServerEventAppExt for App {
     }
 }
 
-fn receiving_system<T: Event + DeserializeOwned + Debug>(
+fn receiving_system<T: Event + DeserializeOwned>(
     mut server_events: EventWriter<T>,
     mut client: ResMut<RenetClient>,
     channel: Res<EventChannel<T>>,
@@ -162,12 +159,12 @@ fn receiving_system<T: Event + DeserializeOwned + Debug>(
         let event = DefaultOptions::new()
             .deserialize(&message)
             .expect("server should send valid events");
-        debug!("received event {event:?} from server");
+
         server_events.send(event);
     }
 }
 
-fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned + Debug>(
+fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned>(
     mut server_events: EventWriter<T>,
     mut client: ResMut<RenetClient>,
     entity_map: Res<ServerEntityMap>,
@@ -177,57 +174,13 @@ fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned
         let mut event: T = DefaultOptions::new()
             .deserialize(&message)
             .expect("server should send valid mapped events");
-        debug!("received mapped event {event:?} from server");
+
         event.map_entities(&mut EventMapper(entity_map.to_client()));
         server_events.send(event);
     }
 }
 
-fn receiving_reflect_system<T, D>(
-    mut server_events: EventWriter<T>,
-    mut client: ResMut<RenetClient>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + Debug,
-    D: BuildEventDeserializer,
-    for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-{
-    let registry = registry.read();
-    while let Some(message) = client.receive_message(channel.id) {
-        let mut deserializer = bincode::Deserializer::from_slice(&message, DefaultOptions::new());
-        let event = D::new(&registry)
-            .deserialize(&mut deserializer)
-            .expect("server should send valid reflect events");
-        debug!("received reflect event {event:?} from server");
-        server_events.send(event);
-    }
-}
-
-fn receiving_and_mapping_reflect_system<T, D>(
-    mut server_events: EventWriter<T>,
-    mut client: ResMut<RenetClient>,
-    entity_map: Res<ServerEntityMap>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + MapNetworkEntities + Debug,
-    D: BuildEventDeserializer,
-    for<'a, 'de> D::EventDeserializer<'a>: DeserializeSeed<'de, Value = T>,
-{
-    let registry = registry.read();
-    while let Some(message) = client.receive_message(channel.id) {
-        let mut deserializer = bincode::Deserializer::from_slice(&message, DefaultOptions::new());
-        let mut event = D::new(&registry)
-            .deserialize(&mut deserializer)
-            .expect("server should send valid mapped reflect events");
-        debug!("received mapped reflect event {event:?} from server");
-        event.map_entities(&mut EventMapper(entity_map.to_client()));
-        server_events.send(event);
-    }
-}
-
-fn sending_system<T: Event + Serialize + Debug>(
+fn sending_system<T: Event + Serialize>(
     mut server: ResMut<RenetServer>,
     mut server_events: EventReader<ToClients<T>>,
     channel: Res<EventChannel<T>>,
@@ -237,64 +190,34 @@ fn sending_system<T: Event + Serialize + Debug>(
             .serialize(&event)
             .expect("server event should be serializable");
 
-        match *mode {
-            SendMode::Broadcast => {
-                server.broadcast_message(channel.id, message);
-                debug!("broadcasted server event {event:?}");
-            }
-            SendMode::BroadcastExcept(client_id) => {
-                if client_id == SERVER_ID {
-                    server.broadcast_message(channel.id, message);
-                } else {
-                    server.broadcast_message_except(client_id, channel.id, message);
-                }
-                debug!("broadcasted server event {event:?} except client {client_id}");
-            }
-            SendMode::Direct(client_id) => {
-                if client_id != SERVER_ID {
-                    server.send_message(client_id, channel.id, message);
-                    debug!("sent direct server event {event:?} to client {client_id}");
-                }
-            }
-        }
+        send(&mut server, *channel, *mode, message);
     }
 }
 
-fn sending_reflect_system<T, S>(
-    mut server: ResMut<RenetServer>,
-    mut server_events: EventReader<ToClients<T>>,
-    channel: Res<EventChannel<T>>,
-    registry: Res<AppTypeRegistry>,
-) where
-    T: Event + Debug,
-    S: BuildEventSerializer<T>,
-    for<'a> S::EventSerializer<'a>: Serialize,
-{
-    let registry = registry.read();
-    for ToClients { event, mode } in &mut server_events {
-        let serializer = S::new(event, &registry);
-        let message = DefaultOptions::new()
-            .serialize(&serializer)
-            .expect("server event should be serializable");
-
-        match *mode {
-            SendMode::Broadcast => {
+/// Sends serialized `message` to clients.
+///
+/// Helper for custom sending system.
+/// See also [`ServerEventAppExt::add_server_event_with`]
+pub fn send<T>(
+    server: &mut RenetServer,
+    channel: EventChannel<T>,
+    mode: SendMode,
+    message: Vec<u8>,
+) {
+    match mode {
+        SendMode::Broadcast => {
+            server.broadcast_message(channel.id, message);
+        }
+        SendMode::BroadcastExcept(client_id) => {
+            if client_id == SERVER_ID {
                 server.broadcast_message(channel.id, message);
-                debug!("broadcasted server reflect event {event:?}");
+            } else {
+                server.broadcast_message_except(client_id, channel.id, message);
             }
-            SendMode::BroadcastExcept(client_id) => {
-                if client_id == SERVER_ID {
-                    server.broadcast_message(channel.id, message);
-                } else {
-                    server.broadcast_message_except(client_id, channel.id, message);
-                }
-                debug!("broadcasted server reflect event {event:?} except client {client_id}");
-            }
-            SendMode::Direct(client_id) => {
-                if client_id != SERVER_ID {
-                    server.send_message(client_id, channel.id, message);
-                    debug!("sent direct server reflect event {event:?} to client {client_id}");
-                }
+        }
+        SendMode::Direct(client_id) => {
+            if client_id != SERVER_ID {
+                server.send_message(client_id, channel.id, message);
             }
         }
     }
@@ -302,25 +225,22 @@ fn sending_reflect_system<T, S>(
 
 /// Transforms [`ToClients<T>`] events into `T` events to "emulate"
 /// message sending for offline mode or when server is also a player
-fn local_resending_system<T: Event + Debug>(
+fn local_resending_system<T: Event>(
     mut server_events: ResMut<Events<ToClients<T>>>,
     mut local_events: EventWriter<T>,
 ) {
     for ToClients { event, mode } in server_events.drain() {
         match mode {
             SendMode::Broadcast => {
-                debug!("converted broadcasted server event {event:?} into a local");
                 local_events.send(event);
             }
             SendMode::BroadcastExcept(client_id) => {
                 if client_id != SERVER_ID {
-                    debug!("converted broadcasted server event {event:?} except client {client_id} into a local");
                     local_events.send(event);
                 }
             }
             SendMode::Direct(client_id) => {
                 if client_id == SERVER_ID {
-                    debug!("converted direct server event {event:?} into a local");
                     local_events.send(event);
                 }
             }

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -1,12 +1,9 @@
 mod common;
 
-use bevy::prelude::*;
-use bevy::{ecs::event::Events, time::TimePlugin};
+use bevy::{ecs::event::Events, prelude::*, time::TimePlugin};
 use bevy_replicon::prelude::*;
 
-use common::{DummyEvent, ReflectEvent, ReflectEventDeserializer, ReflectEventSerializer};
-
-use crate::common::ReflectedValue;
+use common::DummyEvent;
 
 #[test]
 fn without_server_plugin() {
@@ -82,76 +79,6 @@ fn mapping_and_sending_receiving() {
         .resource_mut::<Events<FromClient<DummyEvent>>>()
         .drain()
         .map(|event| event.event.0)
-        .collect();
-    assert_eq!(mapped_entities, [server_entity]);
-}
-
-#[test]
-fn sending_receiving_reflect() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .register_type::<ReflectedValue>()
-            .add_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
-                SendPolicy::Ordered,
-                );
-    }
-
-    common::connect(&mut server_app, &mut client_app);
-
-    client_app
-        .world
-        .resource_mut::<Events<ReflectEvent>>()
-        .send(ReflectEvent {
-            entity: Entity::PLACEHOLDER,
-            reflect: ReflectedValue.clone_value(),
-        });
-
-    client_app.update();
-    server_app.update();
-
-    let client_events = server_app
-        .world
-        .resource::<Events<FromClient<ReflectEvent>>>();
-    assert_eq!(client_events.len(), 1);
-}
-
-#[test]
-fn mapping_and_sending_receiving_reflect() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .register_type::<ReflectedValue>()
-            .add_mapped_client_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
-    }
-
-    common::connect(&mut server_app, &mut client_app);
-
-    let client_entity = Entity::from_raw(0);
-    let server_entity = Entity::from_raw(client_entity.index() + 1);
-    client_app
-        .world
-        .resource_mut::<ServerEntityMap>()
-        .insert(server_entity, client_entity);
-
-    client_app
-        .world
-        .resource_mut::<Events<ReflectEvent>>()
-        .send(ReflectEvent {
-            entity: client_entity,
-            reflect: ReflectedValue.clone_value(),
-        });
-
-    client_app.update();
-    server_app.update();
-
-    let mapped_entities: Vec<_> = server_app
-        .world
-        .resource_mut::<Events<FromClient<ReflectEvent>>>()
-        .drain()
-        .map(|event| event.event.entity)
         .collect();
     assert_eq!(mapped_entities, [server_entity]);
 }

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -1,13 +1,10 @@
 mod common;
 
-use bevy::prelude::*;
-use bevy::{ecs::event::Events, time::TimePlugin};
+use bevy::{ecs::event::Events, prelude::*, time::TimePlugin};
 use bevy_renet::renet::transport::NetcodeClientTransport;
 use bevy_replicon::prelude::*;
 
-use common::{DummyEvent, ReflectEvent, ReflectEventDeserializer, ReflectEventSerializer};
-
-use crate::common::ReflectedValue;
+use common::DummyEvent;
 
 #[test]
 fn without_server_plugin() {
@@ -109,102 +106,6 @@ fn sending_receiving_and_mapping() {
         .resource_mut::<Events<DummyEvent>>()
         .drain()
         .map(|event| event.0)
-        .collect();
-    assert_eq!(mapped_entities, [client_entity]);
-}
-
-#[test]
-fn sending_receiving_reflect() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
-        ))
-        .register_type::<ReflectedValue>()
-        .add_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(
-            SendPolicy::Ordered,
-        );
-    }
-
-    common::connect(&mut server_app, &mut client_app);
-
-    let client_id = client_app
-        .world
-        .resource::<NetcodeClientTransport>()
-        .client_id();
-    for (mode, events_count) in [
-        (SendMode::Broadcast, 1),
-        (SendMode::Direct(SERVER_ID), 0),
-        (SendMode::Direct(client_id), 1),
-        (SendMode::BroadcastExcept(SERVER_ID), 1),
-        (SendMode::BroadcastExcept(client_id), 0),
-    ] {
-        server_app
-            .world
-            .resource_mut::<Events<ToClients<ReflectEvent>>>()
-            .send(ToClients {
-                mode,
-                event: ReflectEvent {
-                    entity: Entity::PLACEHOLDER,
-                    reflect: ReflectedValue.clone_value(),
-                },
-            });
-
-        server_app.update();
-        client_app.update();
-
-        let mut reflect_events = client_app.world.resource_mut::<Events<ReflectEvent>>();
-        assert_eq!(
-            reflect_events.drain().count(),
-            events_count,
-            "event should be emited {events_count} times for {mode:?}"
-        );
-    }
-}
-
-#[test]
-fn sending_receiving_and_mapping_reflect() {
-    let mut server_app = App::new();
-    let mut client_app = App::new();
-    for app in [&mut server_app, &mut client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
-        ))
-        .register_type::<ReflectedValue>()
-        .add_mapped_server_reflect_event::<ReflectEvent, ReflectEventSerializer, ReflectEventDeserializer>(SendPolicy::Ordered);
-    }
-
-    common::connect(&mut server_app, &mut client_app);
-
-    let client_entity = Entity::from_raw(0);
-    let server_entity = Entity::from_raw(client_entity.index() + 1);
-    client_app
-        .world
-        .resource_mut::<ServerEntityMap>()
-        .insert(server_entity, client_entity);
-
-    server_app
-        .world
-        .resource_mut::<Events<ToClients<ReflectEvent>>>()
-        .send(ToClients {
-            mode: SendMode::Broadcast,
-            event: ReflectEvent {
-                entity: server_entity,
-                reflect: ReflectedValue.clone_value(),
-            },
-        });
-
-    server_app.update();
-    client_app.update();
-
-    let mapped_entities: Vec<_> = client_app
-        .world
-        .resource_mut::<Events<ReflectEvent>>()
-        .drain()
-        .map(|event| event.entity)
         .collect();
     assert_eq!(mapped_entities, [client_entity]);
 }


### PR DESCRIPTION
Advice users to write them manually instead.
It's even easier because sometime you can directly use reflect serializers from Bevy directly instead of manually writing serde traits which is quite hard.