### PR TITLE
Do not send replication message if there is no changes or events

### DIFF
--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -273,9 +273,9 @@ fn sending_system<T: Event + Serialize>(
     }
 }
 
-/// Updates [`MinRepliconTick`] to force server to send replication message even if there was no world changes.
+/// Updates [`MinRepliconTick`] to force server to send replication message even if there were no world changes.
 ///
-/// Needed because events on a client won't be emitted until the client acknowledge the event tick.
+/// Needed because events on a client won't be emitted until the client acknowledges the event tick.
 /// See also [`ServerEventQueue`].
 fn min_tick_update_system<T: Event>(
     mut server_events: EventReader<ToClients<T>>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -52,6 +52,7 @@ impl Plugin for ServerPlugin {
         ))
         .init_resource::<AckedTicks>()
         .init_resource::<RepliconTick>()
+        .init_resource::<MinRepliconTick>()
         .init_resource::<ClientEntityMap>()
         .configure_set(
             PreUpdate,
@@ -151,20 +152,26 @@ impl ServerPlugin {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn replication_sending_system(
+    pub(super) fn replication_sending_system(
         mut buffers: Local<Vec<ReplicationBuffer>>,
         change_tick: SystemChangeTick,
         mut set: ParamSet<(&World, ResMut<RenetServer>, ResMut<AckedTicks>)>,
         replication_rules: Res<ReplicationRules>,
         despawn_tracker: Res<DespawnTracker>,
         replicon_tick: Res<RepliconTick>,
+        min_replicon_tick: Res<MinRepliconTick>,
         removal_trackers: Query<(Entity, &RemovalTracker)>,
         entity_map: Res<ClientEntityMap>,
     ) -> Result<(), bincode::Error> {
         let mut acked_ticks = set.p2();
         acked_ticks.register_tick(*replicon_tick, change_tick.this_run());
 
-        let buffers = prepare_buffers(&mut buffers, &acked_ticks, *replicon_tick)?;
+        let buffers = prepare_buffers(
+            &mut buffers,
+            &acked_ticks,
+            *replicon_tick,
+            *min_replicon_tick,
+        )?;
 
         collect_mappings(buffers, &entity_map)?;
         collect_changes(
@@ -199,18 +206,24 @@ fn prepare_buffers<'a>(
     buffers: &'a mut Vec<ReplicationBuffer>,
     acked_ticks: &AckedTicks,
     replicon_tick: RepliconTick,
+    min_replicon_tick: MinRepliconTick,
 ) -> Result<&'a mut [ReplicationBuffer], bincode::Error> {
     buffers.reserve(acked_ticks.clients.len());
-    for (index, (&client_id, &tick)) in acked_ticks.clients.iter().enumerate() {
-        let system_tick = *acked_ticks.system_ticks.get(&tick).unwrap_or(&Tick::new(0));
+    for (index, (&client_id, &acked_tick)) in acked_ticks.clients.iter().enumerate() {
+        let system_tick = *acked_ticks
+            .system_ticks
+            .get(&acked_tick)
+            .unwrap_or(&Tick::new(0));
 
+        let send_empty = acked_tick < *min_replicon_tick;
         if let Some(buffer) = buffers.get_mut(index) {
-            buffer.reset(client_id, system_tick, replicon_tick)?;
+            buffer.reset(client_id, system_tick, replicon_tick, send_empty)?;
         } else {
             buffers.push(ReplicationBuffer::new(
                 client_id,
                 system_tick,
                 replicon_tick,
+                send_empty,
             )?);
         }
     }
@@ -450,6 +463,15 @@ impl AckedTicks {
         &self.clients
     }
 }
+
+/// Contains minimal tick that should be acknowledged by a client.
+///
+/// If a client has not acked this tick, then replication message with
+/// the tick will be sent even if it does not contain data.
+///
+/// Used by events that rely on client to acknowledge tick they were emitted.
+#[derive(Clone, Copy, Debug, Default, Deref, DerefMut, Resource)]
+pub(super) struct MinRepliconTick(RepliconTick);
 
 /// Fills scene with all replicated entities and their components.
 ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -464,12 +464,15 @@ impl AckedTicks {
     }
 }
 
-/// Contains minimal tick that should be acknowledged by a client.
+/// Contains the lowest replicon tick that should be acknowledged by clients.
 ///
-/// If a client has not acked this tick, then replication message with
-/// the tick will be sent even if it does not contain data.
+/// If a client has not acked this tick, then replication messages >= this tick
+/// will be sent even if they do not contain data.
 ///
-/// Used by events that rely on client to acknowledge tick they were emitted.
+/// Used to synchronize server-sent events with clients. A client cannot consume
+/// a server-sent event until it has acknowledged the tick where that event was
+/// created. This means we need to replicate ticks after a server-sent event is
+/// emitted to guarantee the client can eventually consume the event.
 #[derive(Clone, Copy, Debug, Default, Deref, DerefMut, Resource)]
 pub(super) struct MinRepliconTick(RepliconTick);
 

--- a/src/server/despawn_tracker.rs
+++ b/src/server/despawn_tracker.rs
@@ -56,7 +56,7 @@ impl DespawnTrackerPlugin {
 
 /// Entities and ticks when they were despawned.
 #[derive(Default, Resource, Deref, DerefMut)]
-pub(super) struct DespawnTracker(pub(super) Vec<(Entity, Tick)>);
+pub(crate) struct DespawnTracker(pub(super) Vec<(Entity, Tick)>);
 
 #[cfg(test)]
 mod tests {

--- a/src/server/removal_tracker.rs
+++ b/src/server/removal_tracker.rs
@@ -80,7 +80,7 @@ impl RemovalTrackerPlugin {
 }
 
 #[derive(Component, Default, Deref, DerefMut)]
-pub(super) struct RemovalTracker(pub(super) HashMap<ReplicationId, Tick>);
+pub(crate) struct RemovalTracker(pub(super) HashMap<ReplicationId, Tick>);
 
 #[cfg(test)]
 mod tests {

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -32,7 +32,7 @@ fn acked_ticks_cleanup() {
 }
 
 #[test]
-fn tick_acks_receiving() {
+fn no_empty_messages() {
     let mut server_app = App::new();
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
@@ -47,13 +47,13 @@ fn tick_acks_receiving() {
     client_app.update();
     server_app.update();
 
-    let acked_ticks = server_app.world.resource::<AckedTicks>();
     let client_id = client_app
         .world
         .resource::<NetcodeClientTransport>()
         .client_id();
+    let acked_ticks = server_app.world.resource::<AckedTicks>();
     let acked_tick = acked_ticks.acked_ticks()[&client_id];
-    assert_eq!(acked_tick.get(), 3);
+    assert_eq!(acked_tick.get(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Since the sending system is now visible to events, I had to change the visibility of some structures to `crate`.