### PR TITLE
Rename `SendPolicy` into `EventType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `SendPolicy` into `EventType`.
+
 ## [0.15.1] - 2023-10-22
 
 ### Changed

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -35,7 +35,7 @@ impl Plugin for SimpleBoxPlugin {
     fn build(&self, app: &mut App) {
         app.replicate::<PlayerPosition>()
             .replicate::<PlayerColor>()
-            .add_client_event::<MoveDirection>(SendPolicy::Ordered)
+            .add_client_event::<MoveDirection>(EventType::Ordered)
             .add_systems(
                 Startup,
                 (

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -51,7 +51,7 @@ impl Plugin for TicTacToePlugin {
             .replicate::<Symbol>()
             .replicate::<CellIndex>()
             .replicate::<Player>()
-            .add_client_event::<CellPick>(SendPolicy::Ordered)
+            .add_client_event::<CellPick>(EventType::Ordered)
             .insert_resource(ClearColor(BACKGROUND_COLOR))
             .add_systems(
                 Startup,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,9 @@ contains sender ID and the sent event. We consider the authority machine
 This way your game logic will work the same on client, server and in
 single-player session.
 
-Events include [`SendPolicy`] to configure delivery guarantees (reliability and
+Events include [`EventType`] to configure delivery guarantees (reliability and
 ordering). You can alternatively pass in `SendType` from Renet directly if you
-need custom configuration for a reliable policy's `resend_time`.
+need to configure resend time.
 
 ```
 # use bevy::prelude::*;
@@ -246,7 +246,7 @@ need custom configuration for a reliable policy's `resend_time`.
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(ReplicationPlugins);
-app.add_client_event::<DummyEvent>(SendPolicy::Ordered)
+app.add_client_event::<DummyEvent>(EventType::Ordered)
     .add_systems(Update, event_sending_system);
 
 fn event_sending_system(mut dummy_events: EventWriter<DummyEvent>) {
@@ -273,7 +273,7 @@ To do this, use [`ClientEventAppExt::add_mapped_client_event()`] and implement [
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(ReplicationPlugins);
-app.add_mapped_client_event::<MappedEvent>(SendPolicy::Ordered);
+app.add_mapped_client_event::<MappedEvent>(EventType::Ordered);
 
 #[derive(Debug, Deserialize, Event, Serialize)]
 struct MappedEvent(Entity);
@@ -304,7 +304,7 @@ from the send list):
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(ReplicationPlugins);
-app.add_server_event::<DummyEvent>(SendPolicy::Ordered)
+app.add_server_event::<DummyEvent>(EventType::Ordered)
     .add_systems(Update, event_sending_system);
 
 fn event_sending_system(mut dummy_events: EventWriter<ToClients<DummyEvent>>) {
@@ -400,7 +400,7 @@ pub mod prelude {
         network_event::{
             client_event::{ClientEventAppExt, FromClient},
             server_event::{SendMode, ServerEventAppExt, ServerEventQueue, ToClients},
-            EventChannel, EventMapper, SendPolicy,
+            EventChannel, EventMapper, EventType,
         },
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},

--- a/src/network_event.rs
+++ b/src/network_event.rs
@@ -39,25 +39,28 @@ impl<T> From<EventChannel<T>> for u8 {
 }
 
 /// Event delivery guarantee.
+///
+/// Mirrors [`SendType`] and can be converted into it with `resend_time` set to 300ms for reliable types.
+/// Provided for convenient defaults.
 #[derive(Clone, Copy, Debug)]
-pub enum SendPolicy {
-    /// Unreliable and unordered
+pub enum EventType {
+    /// Unreliable and unordered.
     Unreliable,
-    /// Reliable and unordered
+    /// Reliable and unordered.
     Unordered,
-    /// Reliable and ordered
+    /// Reliable and ordered.
     Ordered,
 }
 
-impl From<SendPolicy> for SendType {
-    fn from(policy: SendPolicy) -> Self {
+impl From<EventType> for SendType {
+    fn from(policy: EventType) -> Self {
         const RESEND_TIME: Duration = Duration::from_millis(300);
         match policy {
-            SendPolicy::Unreliable => SendType::Unreliable,
-            SendPolicy::Unordered => SendType::ReliableUnordered {
+            EventType::Unreliable => SendType::Unreliable,
+            EventType::Unordered => SendType::ReliableUnordered {
                 resend_time: RESEND_TIME,
             },
-            SendPolicy::Ordered => SendType::ReliableOrdered {
+            EventType::Ordered => SendType::ReliableOrdered {
                 resend_time: RESEND_TIME,
             },
         }

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -46,7 +46,7 @@ pub trait ClientEventAppExt {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, ReplicationPlugins));
     app.add_client_event_with::<ReflectEvent, _, _>(
-        SendPolicy::Ordered,
+        EventType::Ordered,
         sending_reflect_system,
         receiving_reflect_system,
     );

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -58,7 +58,7 @@ pub trait ServerEventAppExt {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, ReplicationPlugins));
     app.add_server_event_with::<ReflectEvent, _, _>(
-        SendPolicy::Ordered,
+        EventType::Ordered,
         sending_reflect_system,
         receiving_reflect_system,
     );

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -12,7 +12,7 @@ fn without_server_plugin() {
         MinimalPlugins,
         ReplicationPlugins.build().disable::<ServerPlugin>(),
     ))
-    .add_client_event_with::<DummyEvent, _, _>(SendPolicy::Ordered, || {}, || {})
+    .add_client_event_with::<DummyEvent, _, _>(EventType::Ordered, || {}, || {})
     .update();
 }
 
@@ -23,7 +23,7 @@ fn without_client_plugin() {
         MinimalPlugins,
         ReplicationPlugins.build().disable::<ClientPlugin>(),
     ))
-    .add_client_event_with::<DummyEvent, _, _>(SendPolicy::Ordered, || {}, || {})
+    .add_client_event_with::<DummyEvent, _, _>(EventType::Ordered, || {}, || {})
     .update();
 }
 
@@ -33,7 +33,7 @@ fn sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .add_client_event::<DummyEvent>(SendPolicy::Ordered);
+            .add_client_event::<DummyEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);
@@ -58,7 +58,7 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .add_mapped_client_event::<DummyEvent>(SendPolicy::Ordered);
+            .add_mapped_client_event::<DummyEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);
@@ -91,7 +91,7 @@ fn mapping_and_sending_receiving() {
 fn local_resending() {
     let mut app = App::new();
     app.add_plugins((TimePlugin, ReplicationPlugins))
-        .add_client_event::<DummyEvent>(SendPolicy::Ordered);
+        .add_client_event::<DummyEvent>(EventType::Ordered);
 
     app.world
         .resource_mut::<Events<DummyEvent>>()

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -13,7 +13,7 @@ fn without_server_plugin() {
         MinimalPlugins,
         ReplicationPlugins.build().disable::<ServerPlugin>(),
     ))
-    .add_server_event_with::<DummyEvent, _, _>(SendPolicy::Ordered, || {}, || {})
+    .add_server_event_with::<DummyEvent, _, _>(EventType::Ordered, || {}, || {})
     .update();
 }
 
@@ -24,7 +24,7 @@ fn without_client_plugin() {
         MinimalPlugins,
         ReplicationPlugins.build().disable::<ClientPlugin>(),
     ))
-    .add_server_event_with::<DummyEvent, _, _>(SendPolicy::Ordered, || {}, || {})
+    .add_server_event_with::<DummyEvent, _, _>(EventType::Ordered, || {}, || {})
     .update();
 }
 
@@ -37,7 +37,7 @@ fn sending_receiving() {
             MinimalPlugins,
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
-        .add_server_event::<DummyEvent>(SendPolicy::Ordered);
+        .add_server_event::<DummyEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);
@@ -82,7 +82,7 @@ fn sending_receiving_and_mapping() {
             MinimalPlugins,
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
-        .add_mapped_server_event::<DummyEvent>(SendPolicy::Ordered);
+        .add_mapped_server_event::<DummyEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);
@@ -121,7 +121,7 @@ fn local_resending() {
         TimePlugin,
         ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
     ))
-    .add_server_event::<DummyEvent>(SendPolicy::Ordered);
+    .add_server_event::<DummyEvent>(EventType::Ordered);
 
     const DUMMY_CLIENT_ID: u64 = 1;
     for (mode, events_count) in [
@@ -161,7 +161,7 @@ fn event_queue() {
             MinimalPlugins,
             ReplicationPlugins.set(ServerPlugin::new(TickPolicy::EveryFrame)),
         ))
-        .add_server_event::<DummyEvent>(SendPolicy::Ordered);
+        .add_server_event::<DummyEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);


### PR DESCRIPTION
I think this name is more obvious, a bit shorter and plays better with `SendType`.