### PR TITLE
Add API to configure max channel usage bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- API to configure max channel usage bytes in `NetworkChannels`.
+
 ### Changed
 
 - Rename `SendPolicy` into `EventType`.
+- Rename `NetworkChannels::server_channels` into `NetworkChannels::get_server_configs`.
+- Rename `NetworkChannels::client_channels` into `NetworkChannels::get_client_configs`.
 
 ## [0.15.1] - 2023-10-22
 

--- a/examples/simple_box.rs
+++ b/examples/simple_box.rs
@@ -65,8 +65,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Server { port } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let server = RenetServer::new(ConnectionConfig {
                     server_channels_config,
@@ -99,8 +99,8 @@ impl SimpleBoxPlugin {
                 commands.spawn(PlayerBundle::new(SERVER_ID, Vec2::ZERO, Color::GREEN));
             }
             Cli::Client { port, ip } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let client = RenetClient::new(ConnectionConfig {
                     server_channels_config,

--- a/examples/tic_tac_toe.rs
+++ b/examples/tic_tac_toe.rs
@@ -254,8 +254,8 @@ impl TicTacToePlugin {
                 game_state.set(GameState::InGame);
             }
             Cli::Server { port, symbol } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let server = RenetServer::new(ConnectionConfig {
                     server_channels_config,
@@ -279,8 +279,8 @@ impl TicTacToePlugin {
                 commands.spawn(PlayerBundle::server(symbol));
             }
             Cli::Client { port, ip } => {
-                let server_channels_config = network_channels.server_channels();
-                let client_channels_config = network_channels.client_channels();
+                let server_channels_config = network_channels.get_server_configs();
+                let client_channels_config = network_channels.get_client_configs();
 
                 let client = RenetClient::new(ConnectionConfig {
                     server_channels_config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,8 +352,8 @@ use bevy_replicon::{prelude::*, renet::ConnectionConfig};
 # app.add_plugins(ReplicationPlugins);
 let network_channels = app.world.resource::<NetworkChannels>();
 let connection_config = ConnectionConfig {
-    server_channels_config: network_channels.server_channels(),
-    client_channels_config: network_channels.client_channels(),
+    server_channels_config: network_channels.get_server_configs(),
+    client_channels_config: network_channels.get_client_configs(),
     ..Default::default()
 };
 ```
@@ -410,7 +410,7 @@ pub mod prelude {
                 ReplicationRules,
             },
             replicon_tick::RepliconTick,
-            NetworkChannels, RepliconCorePlugin,
+            NetworkChannels, RepliconCorePlugin, REPLICATION_CHANNEL_ID,
         },
         server::{
             has_authority, AckedTicks, ClientEntityMap, ClientMapping, ServerPlugin, ServerSet,

--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -16,59 +16,106 @@ impl Plugin for RepliconCorePlugin {
     }
 }
 
-pub(super) const REPLICATION_CHANNEL_ID: u8 = 0;
+/// ID of the server replication channel.
+///
+/// See also [`NetworkChannels`].
+pub const REPLICATION_CHANNEL_ID: u8 = 0;
 
-/// A resource to create channels for [`bevy_renet::renet::ConnectionConfig`]
-/// based on number of added server and client events.
-#[derive(Clone, Default, Resource)]
+/// A resource to configure and setup channels for [`ConnectionConfig`](bevy_renet::renet::ConnectionConfig)
+#[derive(Clone, Resource)]
 pub struct NetworkChannels {
-    /// Grows with each server event registration.
-    server: Vec<SendType>,
-    /// Grows with each client event registration.
-    client: Vec<SendType>,
+    /// Stores delivery guarantee and maximum usage bytes (if set) for each server channel.
+    server: Vec<(SendType, Option<usize>)>,
+
+    /// Same as [`Self::server`], but for client.
+    client: Vec<(SendType, Option<usize>)>,
+
+    /// Stores default max memory usage bytes for all channels.
+    ///
+    /// This value will be used instead of `None`.
+    default_max_bytes: usize,
+}
+
+/// Stores only replication channel by default.
+impl Default for NetworkChannels {
+    fn default() -> Self {
+        Self {
+            server: vec![(SendType::Unreliable, None)],
+            client: vec![(SendType::Unreliable, None)],
+            default_max_bytes: 5 * 1024 * 1024, // Value from `DefaultChannel::config()`.
+        }
+    }
 }
 
 impl NetworkChannels {
-    pub fn server_channels(&self) -> Vec<ChannelConfig> {
-        channel_configs(&self.server)
+    /// Returns server channel configs that can be used to create [`ConnectionConfig`](bevy_renet::renet::ConnectionConfig).
+    pub fn get_server_configs(&self) -> Vec<ChannelConfig> {
+        self.get_configs(&self.server)
     }
 
-    pub fn client_channels(&self) -> Vec<ChannelConfig> {
-        channel_configs(&self.client)
+    /// Same as [`Self::get_server_configs`], but for client.
+    pub fn get_client_configs(&self) -> Vec<ChannelConfig> {
+        self.get_configs(&self.client)
+    }
+
+    /// Sets maximum usage bytes for specific client channel.
+    ///
+    /// [`REPLICATION_CHANNEL_ID`] or [`EventChannel<T>`](crate::network_event::EventChannel) can be passed as `id`.
+    /// Without calling this function, the default value will be used.
+    /// See also [`Self::set_default_max_bytes`].
+    pub fn set_server_max_bytes(&mut self, id: impl Into<u8>, max_bytes: usize) {
+        let id = id.into() as usize;
+        let (_, bytes) = self
+            .server
+            .get_mut(id)
+            .unwrap_or_else(|| panic!("there is no server channel with id {id}"));
+
+        *bytes = Some(max_bytes);
+    }
+
+    /// Same as [`Self::set_server_max_bytes`], but for client.
+    pub fn set_client_max_bytes(&mut self, id: impl Into<u8>, max_bytes: usize) {
+        let id = id.into();
+        let (_, bytes) = self
+            .client
+            .get_mut(id as usize)
+            .unwrap_or_else(|| panic!("there is no client channel with id {id}"));
+
+        *bytes = Some(max_bytes);
+    }
+
+    /// Sets maximum usage bytes that will be used by default for all channels if not set.
+    pub fn set_default_max_bytes(&mut self, max_bytes: usize) {
+        self.default_max_bytes = max_bytes;
     }
 
     pub(super) fn create_client_channel(&mut self, send_type: SendType) -> u8 {
-        if self.client.len() == REPLICATION_CHANNEL_ID as usize + u8::MAX as usize {
-            panic!("max client channels exceeded u8::MAX");
+        if self.client.len() == u8::MAX as usize {
+            panic!("number of client channels shouldn't exceed u8::MAX");
         }
-        self.client.push(send_type);
-        self.client.len() as u8 + REPLICATION_CHANNEL_ID
+
+        self.client.push((send_type, None));
+        self.client.len() as u8 - 1
     }
 
     pub(super) fn create_server_channel(&mut self, send_type: SendType) -> u8 {
-        if self.server.len() == REPLICATION_CHANNEL_ID as usize + u8::MAX as usize {
-            panic!("max server channels exceeded u8::MAX");
+        if self.server.len() == u8::MAX as usize {
+            panic!("number of server channels shouldn't exceed u8::MAX");
         }
-        self.server.push(send_type);
-        self.server.len() as u8 + REPLICATION_CHANNEL_ID
-    }
-}
 
-fn channel_configs(channels: &[SendType]) -> Vec<ChannelConfig> {
-    let mut channel_configs = Vec::with_capacity(channels.len() + 1);
-    // TODO: Make it configurable.
-    // Values from `DefaultChannel::config()`.
-    channel_configs.push(ChannelConfig {
-        channel_id: REPLICATION_CHANNEL_ID,
-        max_memory_usage_bytes: 5 * 1024 * 1024,
-        send_type: SendType::Unreliable,
-    });
-    for (idx, send_type) in channels.iter().enumerate() {
-        channel_configs.push(ChannelConfig {
-            channel_id: REPLICATION_CHANNEL_ID + 1 + idx as u8,
-            max_memory_usage_bytes: 5 * 1024 * 1024,
-            send_type: send_type.clone(),
-        });
+        self.server.push((send_type, None));
+        self.server.len() as u8 - 1
     }
-    channel_configs
+
+    fn get_configs(&self, channels: &[(SendType, Option<usize>)]) -> Vec<ChannelConfig> {
+        let mut channel_configs = Vec::with_capacity(channels.len());
+        for (index, (send_type, max_bytes)) in channels.iter().enumerate() {
+            channel_configs.push(ChannelConfig {
+                channel_id: index as u8,
+                max_memory_usage_bytes: max_bytes.unwrap_or(self.default_max_bytes),
+                send_type: send_type.clone(),
+            });
+        }
+        channel_configs
+    }
 }


### PR DESCRIPTION
Changes:
- Add API to configure max channel usage bytes in `NetworkChannels`.
- Rename `NetworkChannels::server_channels` into `NetworkChannels::get_server_configs`.
- Rename `NetworkChannels::client_channels` into `NetworkChannels::get_client_configs`.
- Simplify connection setup in tests.

Mainly fixes TODO and uses configurable values instead of the hardcoded constant.
Suggestions about the API are welcome.