### PR TITLE
Use `Cursor<&[u8]>` instead of `Cursor<Bytes>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use `EntityHashMap` instead of `HashMap` with entities as keys.
+- Use `Cursor<&[u8]>` instead of `Cursor<Bytes>`.
 - Rename `replicate_into_scene` into `replicate_into` and move it to `scene` module.
 
 ## [0.17.0] - 2023-11-13

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ you can use [`AppReplicationExt::replicate_with`]:
 ```
 use std::io::Cursor;
 use bevy::{prelude::*, ptr::Ptr};
-use bevy_replicon::{prelude::*, renet::Bytes, replicon_core::replication_rules};
+use bevy_replicon::{prelude::*, replicon_core::replication_rules};
 use serde::{Deserialize, Serialize};
 
 # let mut app = App::new();
@@ -116,7 +116,7 @@ fn serialize_transform(
 fn deserialize_transform(
     entity: &mut EntityWorldMut,
     _entity_map: &mut ServerEntityMap,
-    cursor: &mut Cursor<Bytes>,
+    cursor: &mut Cursor<&[u8]>,
     _tick: RepliconTick,
 ) -> bincode::Result<()> {
     let translation: Vec3 = bincode::deserialize_from(cursor)?;
@@ -169,7 +169,7 @@ your initialization systems to [`ClientSet::Receive`]:
 ```
 # use std::io::Cursor;
 # use bevy::{prelude::*, ptr::Ptr};
-# use bevy_replicon::{prelude::*, renet::Bytes, replicon_core::replication_rules};
+# use bevy_replicon::{prelude::*, replicon_core::replication_rules};
 # use serde::{Deserialize, Serialize};
 # let mut app = App::new();
 # app.add_plugins(ReplicationPlugins);
@@ -196,7 +196,7 @@ fn player_init_system(
 #[derive(Component, Deserialize, Serialize)]
 struct Player;
 # fn serialize_transform(_: Ptr, _: &mut Cursor<Vec<u8>>) -> bincode::Result<()> { unimplemented!() }
-# fn deserialize_transform(_: &mut EntityWorldMut, _: &mut ServerEntityMap, _: &mut Cursor<Bytes>, _: RepliconTick) -> bincode::Result<()> { unimplemented!() }
+# fn deserialize_transform(_: &mut EntityWorldMut, _: &mut ServerEntityMap, _: &mut Cursor<&[u8]>, _: RepliconTick) -> bincode::Result<()> { unimplemented!() }
 ```
 
 This pairs nicely with server state serialization and keeps saves clean.

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -1,7 +1,6 @@
 use std::{io::Cursor, marker::PhantomData};
 
 use bevy::{ecs::component::ComponentId, prelude::*, ptr::Ptr, utils::HashMap};
-use bevy_renet::renet::Bytes;
 use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -159,7 +158,7 @@ pub type SerializeFn = fn(Ptr, &mut Cursor<Vec<u8>>) -> bincode::Result<()>;
 pub type DeserializeFn = fn(
     &mut EntityWorldMut,
     &mut ServerEntityMap,
-    &mut Cursor<Bytes>,
+    &mut Cursor<&[u8]>,
     RepliconTick,
 ) -> bincode::Result<()>;
 
@@ -231,7 +230,7 @@ pub fn serialize_component<C: Component + Serialize>(
 pub fn deserialize_component<C: Component + DeserializeOwned>(
     entity: &mut EntityWorldMut,
     _entity_map: &mut ServerEntityMap,
-    cursor: &mut Cursor<Bytes>,
+    cursor: &mut Cursor<&[u8]>,
     _tick: RepliconTick,
 ) -> bincode::Result<()> {
     let component: C = DefaultOptions::new().deserialize_from(cursor)?;
@@ -244,7 +243,7 @@ pub fn deserialize_component<C: Component + DeserializeOwned>(
 pub fn deserialize_mapped_component<C: Component + DeserializeOwned + MapNetworkEntities>(
     entity: &mut EntityWorldMut,
     entity_map: &mut ServerEntityMap,
-    cursor: &mut Cursor<Bytes>,
+    cursor: &mut Cursor<&[u8]>,
     _tick: RepliconTick,
 ) -> bincode::Result<()> {
     let mut component: C = DefaultOptions::new().deserialize_from(cursor)?;


### PR DESCRIPTION
It's makes sense in general, but I also need to make it non-owning to buffer messages.