### PR TITLE
Move out ticks map from `AckedTicks` into a separate resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `TicksMap` with mapping from server ticks to system change ticks.
+
 ### Changed
 
 - Use `EntityHashMap` instead of `HashMap` with entities as keys.
 - Use `Cursor<&[u8]>` instead of `Cursor<Bytes>`.
 - Replace `LastRepliconTick` with `RepliconTick` on client.
+- `AckedTicks` now returns the map via `deref` instead of via separate method.
 - Fix missing reset of `RepliconTick` on server disconnect.
 - Rename `replicate_into_scene` into `replicate_into` and move it to `scene` module.
 

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -28,7 +28,7 @@ fn acked_ticks_cleanup() {
     server_app.update();
 
     let acked_ticks = server_app.world.resource::<AckedTicks>();
-    assert!(!acked_ticks.acked_ticks().contains_key(&client_id));
+    assert!(!acked_ticks.contains_key(&client_id));
 }
 
 #[test]


### PR DESCRIPTION
Not only more clear and ergonomic to use, but I also need this separation to avoid borrowing issues with the upcoming manual packet fragmentation.