### PR TITLE
Move `ClientMapper` and `ServerEntityMap` to `client_mapper` submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `EntityHashMap` instead of `HashMap` with entities as keys.
 - Use `Cursor<&[u8]>` instead of `Cursor<Bytes>`.
 - Replace `LastRepliconTick` with `RepliconTick` on client.
+- Move `ClientMapper` and `ServerEntityMap` to `client_mapper` submodule.
 - Fix missing reset of `RepliconTick` on server disconnect.
 - Rename `replicate_into_scene` into `replicate_into` and move it to `scene` module.
 - Derive `Debug` for `Replication` and `Ignored<T>`.

--- a/src/client/client_mapper.rs
+++ b/src/client/client_mapper.rs
@@ -1,0 +1,108 @@
+use bevy::{
+    prelude::*,
+    utils::{hashbrown::hash_map::Entry, EntityHashMap},
+};
+
+use crate::replicon_core::replication_rules::{Mapper, Replication};
+
+/// Maps server entities into client entities inside components.
+///
+/// Spawns new client entity if a mapping doesn't exists.
+pub struct ClientMapper<'a> {
+    world: &'a mut World,
+    server_to_client: &'a mut EntityHashMap<Entity, Entity>,
+    client_to_server: &'a mut EntityHashMap<Entity, Entity>,
+}
+
+impl<'a> ClientMapper<'a> {
+    #[inline]
+    pub fn new(world: &'a mut World, entity_map: &'a mut ServerEntityMap) -> Self {
+        Self {
+            world,
+            server_to_client: &mut entity_map.server_to_client,
+            client_to_server: &mut entity_map.client_to_server,
+        }
+    }
+}
+
+impl Mapper for ClientMapper<'_> {
+    fn map(&mut self, entity: Entity) -> Entity {
+        *self.server_to_client.entry(entity).or_insert_with(|| {
+            let client_entity = self.world.spawn(Replication).id();
+            self.client_to_server.insert(client_entity, entity);
+            client_entity
+        })
+    }
+}
+
+/// Maps server entities to client entities and vice versa.
+#[derive(Default, Resource)]
+pub struct ServerEntityMap {
+    server_to_client: EntityHashMap<Entity, Entity>,
+    client_to_server: EntityHashMap<Entity, Entity>,
+}
+
+impl ServerEntityMap {
+    /// Inserts a server-client pair into the map.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this mapping is already present.
+    #[inline]
+    pub fn insert(&mut self, server_entity: Entity, client_entity: Entity) {
+        if let Some(existing_entity) = self.server_to_client.insert(server_entity, client_entity) {
+            panic!("mapping {server_entity:?} to {client_entity:?}, but it's already mapped to {existing_entity:?}");
+        }
+        self.client_to_server.insert(client_entity, server_entity);
+    }
+
+    pub(super) fn get_by_server_or_spawn<'a>(
+        &mut self,
+        world: &'a mut World,
+        server_entity: Entity,
+    ) -> EntityWorldMut<'a> {
+        match self.server_to_client.entry(server_entity) {
+            Entry::Occupied(entry) => world.entity_mut(*entry.get()),
+            Entry::Vacant(entry) => {
+                let client_entity = world.spawn(Replication);
+                entry.insert(client_entity.id());
+                self.client_to_server
+                    .insert(client_entity.id(), server_entity);
+                client_entity
+            }
+        }
+    }
+
+    pub(super) fn get_by_server<'a>(
+        &mut self,
+        world: &'a mut World,
+        server_entity: Entity,
+    ) -> Option<EntityWorldMut<'a>> {
+        self.server_to_client
+            .get(&server_entity)
+            .map(|&entity| world.entity_mut(entity))
+    }
+
+    pub(super) fn remove_by_server(&mut self, server_entity: Entity) -> Option<Entity> {
+        let client_entity = self.server_to_client.remove(&server_entity);
+        if let Some(client_entity) = client_entity {
+            self.client_to_server.remove(&client_entity);
+        }
+        client_entity
+    }
+
+    #[inline]
+    pub fn to_client(&self) -> &EntityHashMap<Entity, Entity> {
+        &self.server_to_client
+    }
+
+    #[inline]
+    pub fn to_server(&self) -> &EntityHashMap<Entity, Entity> {
+        &self.client_to_server
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.client_to_server.clear();
+        self.server_to_client.clear();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,8 +411,9 @@ pub mod server;
 pub mod prelude {
     pub use super::{
         client::{
+            client_mapper::{ClientMapper, ServerEntityMap},
             diagnostics::{ClientDiagnosticsPlugin, ClientStats},
-            ClientMapper, ClientPlugin, ClientSet, ServerEntityMap,
+            ClientPlugin, ClientSet,
         },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},

--- a/src/network_event/client_event.rs
+++ b/src/network_event/client_event.rs
@@ -8,7 +8,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::EventChannel;
 use crate::{
-    client::{ClientSet, ServerEntityMap},
+    client::{client_mapper::ServerEntityMap, ClientSet},
     network_event::EventMapper,
     replicon_core::{replication_rules::MapNetworkEntities, NetworkChannels},
     server::{has_authority, ServerSet, SERVER_ID},

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -9,7 +9,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::EventChannel;
 use crate::{
-    client::{ClientSet, ServerEntityMap},
+    client::{client_mapper::ServerEntityMap, ClientSet},
     network_event::EventMapper,
     prelude::{ClientPlugin, ServerPlugin},
     replicon_core::{

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -5,7 +5,7 @@ use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::replicon_tick::RepliconTick;
-use crate::client::{ClientMapper, ServerEntityMap};
+use crate::client::client_mapper::{ClientMapper, ServerEntityMap};
 
 pub trait AppReplicationExt {
     /// Marks component for replication.

--- a/src/server.rs
+++ b/src/server.rs
@@ -519,7 +519,7 @@ pub struct LastChangeTick(RepliconTick);
 /**
 A resource that exists on the server for mapping server entities to
 entities that clients have already spawned. The mappings are sent to clients as part of replication
-and injected into the client's [`ServerEntityMap`](crate::client::ServerEntityMap).
+and injected into the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
 
 Sometimes you don't want to wait for the server to spawn something before it appears on the
 client – when a client performs an action, they can immediately simulate it on the client,
@@ -530,9 +530,9 @@ In this situation, the client can send the server its pre-spawned entity id, the
 and inject the [`ClientMapping`] into its [`ClientEntityMap`].
 
 Replication packets will send a list of such mappings to clients, which will
-be inserted into the client's [`ServerEntityMap`](crate::client::ServerEntityMap). Using replication
+be inserted into the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap). Using replication
 to propagate the mappings ensures any replication messages related to the pre-mapped
-server entities will synchronize with updating the client's [`ServerEntityMap`](crate::client::ServerEntityMap).
+server entities will synchronize with updating the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
 
 ### Example:
 
@@ -589,7 +589,7 @@ pub struct ClientEntityMap(HashMap<ClientId, Vec<ClientMapping>>);
 impl ClientEntityMap {
     /// Registers `mapping` for a client entity pre-spawned by the specified client.
     ///
-    /// This will be sent as part of replication data and added to the client's [`ServerEntityMap`](crate::client::ServerEntityMap).
+    /// This will be sent as part of replication data and added to the client's [`ServerEntityMap`](crate::client::client_mapper::ServerEntityMap).
     pub fn insert(&mut self, client_id: ClientId, mapping: ClientMapping) {
         self.0.entry(client_id).or_default().push(mapping);
     }


### PR DESCRIPTION
Because of internal state of `ServerEntityMap` which should be private.