### PR TITLE
Cache replicated archetypes for faster iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Cache replicated archetypes for faster iteration.
+
 ## [0.18.0] - 2023-12-19
 
 ### Changed

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -119,9 +119,9 @@ impl ReplicationRules {
     pub(crate) fn get(
         &self,
         component_id: ComponentId,
-    ) -> Option<(ReplicationId, ReplicationInfo)> {
+    ) -> Option<(ReplicationId, &ReplicationInfo)> {
         let replication_id = self.ids.get(&component_id).copied()?;
-        let replication_info = self.info[replication_id.0];
+        let replication_info = &self.info[replication_id.0];
 
         Some((replication_id, replication_info))
     }
@@ -168,7 +168,7 @@ pub type RemoveComponentFn = fn(&mut EntityWorldMut, RepliconTick);
 pub type EntityDespawnFn = fn(EntityWorldMut, RepliconTick);
 
 /// Stores meta information about replicated component.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct ReplicationInfo {
     /// ID of [`Ignored<T>`] component.
     pub(crate) ignored_id: ComponentId,

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -121,8 +121,7 @@ impl ReplicationRules {
         component_id: ComponentId,
     ) -> Option<(ReplicationId, ReplicationInfo)> {
         let replication_id = self.ids.get(&component_id).copied()?;
-        // SAFETY: ID corresponds to a valid index because it obtained from `ids`.
-        let replication_info = unsafe { *self.info.get_unchecked(replication_id.0) };
+        let replication_info = self.info[replication_id.0];
 
         Some((replication_id, replication_info))
     }

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -134,8 +134,8 @@ impl ReplicationRules {
     pub(crate) unsafe fn get_info_unchecked(
         &self,
         replication_id: ReplicationId,
-    ) -> &ReplicationInfo {
-        self.info.get_unchecked(replication_id.0)
+    ) -> ReplicationInfo {
+        *self.info.get_unchecked(replication_id.0)
     }
 }
 

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -134,8 +134,8 @@ impl ReplicationRules {
     pub(crate) unsafe fn get_info_unchecked(
         &self,
         replication_id: ReplicationId,
-    ) -> ReplicationInfo {
-        *self.info.get_unchecked(replication_id.0)
+    ) -> &ReplicationInfo {
+        self.info.get_unchecked(replication_id.0)
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -315,7 +315,7 @@ fn collect_changes(
                             archetype_entity.entity(),
                             ticks,
                             change_tick,
-                            component_info.replication_info,
+                            &component_info.replication_info,
                             component_info.replication_id,
                             component,
                         )?;
@@ -342,7 +342,7 @@ fn collect_changes(
                             entity,
                             ticks,
                             change_tick,
-                            component_info.replication_info,
+                            &component_info.replication_info,
                             component_info.replication_id,
                             component,
                         )?;
@@ -385,7 +385,7 @@ fn collect_component_change(
     entity: Entity,
     ticks: ComponentTicks,
     change_tick: &SystemChangeTick,
-    replication_info: ReplicationInfo,
+    replication_info: &ReplicationInfo,
     replication_id: ReplicationId,
     component: Ptr,
 ) -> bincode::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -315,7 +315,7 @@ fn collect_changes(
                             archetype_entity.entity(),
                             ticks,
                             change_tick,
-                            &component_info.replication_info,
+                            component_info.replication_info,
                             component_info.replication_id,
                             component,
                         )?;
@@ -342,7 +342,7 @@ fn collect_changes(
                             entity,
                             ticks,
                             change_tick,
-                            &component_info.replication_info,
+                            component_info.replication_info,
                             component_info.replication_id,
                             component,
                         )?;
@@ -385,7 +385,7 @@ fn collect_component_change(
     entity: Entity,
     ticks: ComponentTicks,
     change_tick: &SystemChangeTick,
-    replication_info: &ReplicationInfo,
+    replication_info: ReplicationInfo,
     replication_id: ReplicationId,
     component: Ptr,
 ) -> bincode::Result<()> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -278,6 +278,14 @@ fn collect_changes(
     for archetype_info in archetypes_info.iter() {
         // SAFETY: all IDs from replicated archetypes obtained from real archetypes.
         let archetype = unsafe { world.archetypes().get(archetype_info.id).unwrap_unchecked() };
+        // SAFETY: table obtained from this archetype.
+        let table = unsafe {
+            world
+                .storages()
+                .tables
+                .get(archetype.table_id())
+                .unwrap_unchecked()
+        };
 
         for archetype_entity in archetype.entities() {
             for (init_message, update_message) in messages.iter_mut() {
@@ -288,13 +296,8 @@ fn collect_changes(
             for component_info in &archetype_info.components {
                 match component_info.storage_type {
                     StorageType::Table => {
-                        // SAFETY: component storage and table obtained from this archetype.
+                        // SAFETY: component storage obtained from this archetype.
                         let column = unsafe {
-                            let table = world
-                                .storages()
-                                .tables
-                                .get(archetype.table_id())
-                                .unwrap_unchecked();
                             table
                                 .get_column(component_info.component_id)
                                 .unwrap_unchecked()

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -1,0 +1,91 @@
+use std::mem;
+
+use bevy::{
+    ecs::{
+        archetype::{ArchetypeGeneration, ArchetypeId, Archetypes},
+        component::{ComponentId, StorageType},
+    },
+    prelude::*,
+};
+
+use crate::replicon_core::replication_rules::{ReplicationId, ReplicationInfo, ReplicationRules};
+
+/// Stores cached information about all replicated archetypes.
+pub(crate) struct ReplicatedArchetypesInfo {
+    info: Vec<ReplicatedArchetypeInfo>,
+    generation: ArchetypeGeneration,
+}
+
+impl ReplicatedArchetypesInfo {
+    /// Returns an iterator the archetypes.
+    pub(super) fn iter(&self) -> impl Iterator<Item = &ReplicatedArchetypeInfo> {
+        self.info.iter()
+    }
+
+    /// Updates internal view of the [`World`]'s replicated archetypes.
+    ///
+    /// If this is not called before querying data, the results may not accurately reflect what is in the world.
+    pub(super) fn update(&mut self, archetypes: &Archetypes, replication_rules: &ReplicationRules) {
+        let old_generation = mem::replace(&mut self.generation, archetypes.generation());
+
+        // Archetypes are never removed, iterate over newly added since the last update.
+        for archetype in archetypes[old_generation..]
+            .iter()
+            .filter(|archetype| archetype.contains(replication_rules.get_marker_id()))
+        {
+            let mut archetype_info = ReplicatedArchetypeInfo::new(archetype.id());
+            for component_id in archetype.components() {
+                let Some((replication_id, replication_info)) = replication_rules.get(component_id)
+                else {
+                    continue;
+                };
+                if archetype.contains(replication_info.ignored_id) {
+                    continue;
+                }
+
+                // SAFETY: component ID obtained from this archetype.
+                let storage_type =
+                    unsafe { archetype.get_storage_type(component_id).unwrap_unchecked() };
+
+                archetype_info.components.push(ReplicatedComponentInfo {
+                    component_id,
+                    storage_type,
+                    replication_id,
+                    replication_info,
+                });
+            }
+
+            self.info.push(archetype_info);
+        }
+    }
+}
+
+impl Default for ReplicatedArchetypesInfo {
+    fn default() -> Self {
+        Self {
+            info: default(),
+            generation: ArchetypeGeneration::initial(),
+        }
+    }
+}
+
+pub(super) struct ReplicatedArchetypeInfo {
+    pub(super) id: ArchetypeId,
+    pub(super) components: Vec<ReplicatedComponentInfo>,
+}
+
+impl ReplicatedArchetypeInfo {
+    fn new(id: ArchetypeId) -> Self {
+        Self {
+            id,
+            components: Default::default(),
+        }
+    }
+}
+
+pub(super) struct ReplicatedComponentInfo {
+    pub(super) component_id: ComponentId,
+    pub(super) storage_type: StorageType,
+    pub(super) replication_id: ReplicationId,
+    pub(super) replication_info: ReplicationInfo,
+}

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -51,7 +51,7 @@ impl ReplicatedArchetypesInfo {
                     component_id,
                     storage_type,
                     replication_id,
-                    replication_info,
+                    replication_info: replication_info.clone(),
                 });
             }
 

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -17,7 +17,7 @@ pub(crate) struct ReplicatedArchetypesInfo {
 }
 
 impl ReplicatedArchetypesInfo {
-    /// Returns an iterator the archetypes.
+    /// Returns an iterator over the archetypes.
     pub(super) fn iter(&self) -> impl Iterator<Item = &ReplicatedArchetypeInfo> {
         self.info.iter()
     }

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -239,7 +239,7 @@ impl ReplicationBuffer {
     /// See also [`Self::start_entity_data`].
     pub(super) fn write_component(
         &mut self,
-        replication_info: &ReplicationInfo,
+        replication_info: ReplicationInfo,
         replication_id: ReplicationId,
         ptr: Ptr,
     ) -> bincode::Result<()> {

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -239,7 +239,7 @@ impl ReplicationBuffer {
     /// See also [`Self::start_entity_data`].
     pub(super) fn write_component(
         &mut self,
-        replication_info: ReplicationInfo,
+        replication_info: &ReplicationInfo,
         replication_id: ReplicationId,
         ptr: Ptr,
     ) -> bincode::Result<()> {


### PR DESCRIPTION
Gives nice speedup according to our benchmarks:
```
     Running benches/replication.rs (target/release/deps/replication-c5d7769abd7ff06d)
entities send           time:   [63.425 µs 63.526 µs 63.622 µs]
                        change: [-11.110% -10.897% -10.703%] (p = 0.00 < 0.05)
                        Performance has improved.

entities receive        time:   [135.24 µs 135.43 µs 135.67 µs]
                        change: [-2.9535% -2.3766% -1.8401%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

entities update send    time:   [62.996 µs 63.392 µs 63.810 µs]
                        change: [-10.514% -8.9546% -7.0856%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe

entities update receive time:   [67.951 µs 68.413 µs 68.944 µs]
                        change: [-1.9278% -0.9178% +0.0163%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe
```

But I suspect that it will be a lot faster then the previous approach when there are many archetypes.