### PR TITLE
Fix replacing event channel resource by reusing one T for server and client events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,7 @@ pub mod prelude {
         network_event::{
             client_event::{ClientEventAppExt, FromClient},
             server_event::{SendMode, ServerEventAppExt, ServerEventQueue, ToClients},
-            EventChannel, EventMapper, EventType,
+            ClientEventChannel, EventMapper, EventType, ServerEventChannel,
         },
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},

--- a/src/network_event.rs
+++ b/src/network_event.rs
@@ -8,14 +8,14 @@ use bevy_renet::renet::SendType;
 
 use crate::replicon_core::replication_rules::Mapper;
 
-/// Holds a channel ID for `T`.
+/// Holds a server's channel ID for `T`.
 #[derive(Resource)]
-pub struct EventChannel<T> {
+pub struct ServerEventChannel<T> {
     id: u8,
     marker: PhantomData<T>,
 }
 
-impl<T> EventChannel<T> {
+impl<T> ServerEventChannel<T> {
     fn new(id: u8) -> Self {
         Self {
             id,
@@ -24,16 +24,46 @@ impl<T> EventChannel<T> {
     }
 }
 
-impl<T> Clone for EventChannel<T> {
+impl<T> Clone for ServerEventChannel<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T> Copy for EventChannel<T> {}
+impl<T> Copy for ServerEventChannel<T> {}
 
-impl<T> From<EventChannel<T>> for u8 {
-    fn from(value: EventChannel<T>) -> Self {
+impl<T> From<ServerEventChannel<T>> for u8 {
+    fn from(value: ServerEventChannel<T>) -> Self {
+        value.id
+    }
+}
+
+/// Holds a client's channel ID for `T`.
+#[derive(Resource)]
+pub struct ClientEventChannel<T> {
+    id: u8,
+    marker: PhantomData<T>,
+}
+
+impl<T> ClientEventChannel<T> {
+    fn new(id: u8) -> Self {
+        Self {
+            id,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Clone for ClientEventChannel<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for ClientEventChannel<T> {}
+
+impl<T> From<ClientEventChannel<T>> for u8 {
+    fn from(value: ClientEventChannel<T>) -> Self {
         value.id
     }
 }

--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -86,7 +86,7 @@ impl NetworkChannels {
 
     /// Sets maximum usage bytes for specific client channel.
     ///
-    /// [`ReplicationChannel`] or [`EventChannel<T>`](crate::network_event::EventChannel) can be passed as `id`.
+    /// [`ReplicationChannel`] or [`ServerEventChannel<T>`](crate::network_event::ServerEventChannel) can be passed as `id`.
     /// Without calling this function, the default value will be used.
     /// See also [`Self::set_default_max_bytes`].
     pub fn set_server_max_bytes(&mut self, id: impl Into<u8>, max_bytes: usize) {


### PR DESCRIPTION
I splitted `EventChannel<T>` to different type for server and client, because when user will register in Bevy's `App` the same type twice, for server and client (e.g. when somebody wants to use single type for double-sided communications) this can end with panic.

Registring the same type for both events:
```rs
app.add_server_event::<Foo>(EventType::Ordered).add_client_event::<Foo>(EventType::Ordered);
```
This creates the same `EventChannel<T>` which one (e.g. client's) was replaced by second.

# Good case
This will end by `renet`'s panic in:
```
renet-0.0.14\src\remote_connection.rs:349:13:
Called 'receive_message' with invalid channel 3
```
or:
```
renet-0.0.14\src\remote_connection.rs:333:13:
Called 'send_message' with invalid channel 3
```
depending on the communication side.

Additionally, this panic is quite illegible and comes from several libraries away.

# Terrible case
Code will work correct, until you add totally another event in totally another system. After this little change, another system will just crash a game with panics from good case.

And this case was mine, I spent little time to find out what is wrong, but everything looking fine. You can saw [my code](https://github.com/Vixenka/glass-transition/blob/371174054486ceb6e7ffc9ef9552af59929b645b/src/character/player.rs#L29-L30) which caused this panic. Eventually I plan to change this to case where I will not meet with this problem, but that code started work after my changes from this pull request.