### PR TITLE
Adjustments to support manual cleanup for reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `ClientSet::Reset` which can be disabled by external users. Also moved the client reset system to `PreUpdate` so clients can react more promptly to resets.
+- Added `ServerEntityMap::remove_by_client()` for manual client cleanup.
+- Added `BufferedUpdates`, `ServerEntityTicks` to public API.
+
+
 ## [0.18.2] - 2023-12-27
 
 ### Changed

--- a/src/client.rs
+++ b/src/client.rs
@@ -493,7 +493,8 @@ pub enum ClientSet {
 #[derive(Default, Deref, DerefMut, Resource)]
 pub struct ServerEntityTicks(EntityHashMap<Entity, RepliconTick>);
 
-/// All cached [`BufferedUpdate`]s.
+/// All cached buffered updates, used by the replicon client to align replication updates with initialization
+/// messages.
 ///
 /// If [`ClientSet::Reset`] is disabled, then this needs to be cleaned up manually with [`Self::clear`].
 #[derive(Default, Resource)]

--- a/src/client/client_mapper.rs
+++ b/src/client/client_mapper.rs
@@ -36,6 +36,9 @@ impl Mapper for ClientMapper<'_> {
 }
 
 /// Maps server entities to client entities and vice versa.
+///
+/// If [`ClientSet::Reset`](crate::client::ClientSet) is disabled, then this needs to be cleaned up manually
+/// via [`Self::remove_by_client`] or [`Self::clear`].
 #[derive(Default, Resource)]
 pub struct ServerEntityMap {
     server_to_client: EntityHashMap<Entity, Entity>,
@@ -91,6 +94,17 @@ impl ServerEntityMap {
         client_entity
     }
 
+    /// Remove an entry using the client entity.
+    ///
+    /// Useful for manual cleanup, e.g. after reconnects.
+    pub fn remove_by_client(&mut self, client_entity: Entity) -> Option<Entity> {
+        let server_entity = self.client_to_server.remove(&client_entity);
+        if let Some(server_entity) = server_entity {
+            self.server_to_client.remove(&server_entity);
+        }
+        server_entity
+    }
+
     #[inline]
     pub fn to_client(&self) -> &EntityHashMap<Entity, Entity> {
         &self.server_to_client
@@ -101,7 +115,8 @@ impl ServerEntityMap {
         &self.client_to_server
     }
 
-    pub(super) fn clear(&mut self) {
+    /// Clear the map.
+    pub fn clear(&mut self) {
         self.client_to_server.clear();
         self.server_to_client.clear();
     }

--- a/src/client/client_mapper.rs
+++ b/src/client/client_mapper.rs
@@ -94,7 +94,7 @@ impl ServerEntityMap {
         client_entity
     }
 
-    /// Remove an entry using the client entity.
+    /// Removes an entry using the client entity.
     ///
     /// Useful for manual cleanup, e.g. after reconnects.
     pub fn remove_by_client(&mut self, client_entity: Entity) -> Option<Entity> {
@@ -115,7 +115,7 @@ impl ServerEntityMap {
         &self.client_to_server
     }
 
-    /// Clear the map.
+    /// Clears the map.
     pub fn clear(&mut self) {
         self.client_to_server.clear();
         self.server_to_client.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ pub mod prelude {
         client::{
             client_mapper::{ClientMapper, ServerEntityMap},
             diagnostics::{ClientDiagnosticsPlugin, ClientStats},
-            ClientPlugin, ClientSet,
+            BufferedUpdates, ClientPlugin, ClientSet, ServerEntityTicks,
         },
         network_event::{
             client_event::{ClientEventAppExt, FromClient},


### PR DESCRIPTION
### Problem

It is not possible to [manually repair](https://github.com/lifescapegame/bevy_replicon/issues/121#issuecomment-1867004998) a client after a renet reconnect. A side-plugin for repairing replicon clients after a reconnect is in development [here](https://github.com/UkoeHB/bevy_replicon_repair).

### Solution

- Resolves [this comment](https://github.com/lifescapegame/bevy_replicon/issues/121#issuecomment-1854661248).
- Adds `ClientSet::Reset` which can be disabled by external users.
- Adds `ServerEntityMap::remove_by_client()` for manual client cleanup.
- Adds `BufferedUpdate, BufferedUpdates, ServerEntityTicks` to public API.

### Future work

- Refactor client premapping to use a `ClientMapped` server component instead of a resource, so premappings will persist across a client reconnect.
