### PR TITLE
Spawn empty entities on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ClientSet::Reset` which can be disabled by external users. Also moved the client reset system to `PreUpdate` so clients can react more promptly to resets.
 - Added `ServerEntityMap::remove_by_client()` for manual client cleanup.
 - Added `BufferedUpdates`, `ServerEntityTicks` to public API.
+- `Replication` entities with no replicated components will now be spawned on the client anyway.
 
 
 ## [0.18.2] - 2023-12-27

--- a/src/server.rs
+++ b/src/server.rs
@@ -330,9 +330,9 @@ fn collect_changes(
                 };
 
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                    if new_entity
-                        || client_info.just_connected
-                        || ticks.is_added(change_tick.last_run(), change_tick.this_run())
+                    let must_init = new_entity || client_info.just_connected;
+
+                    if must_init || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
                             &component_info.replication_info,
@@ -356,8 +356,10 @@ fn collect_changes(
             }
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                if init_message.entity_data_len() != 0 {
-                    // If there is any insertion, include all updates into init message
+                let must_init = new_entity || client_info.just_connected;
+
+                if must_init || init_message.entity_data_len() != 0 {
+                    // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.
                     init_message.take_entity_data(update_message);
                     client_info
@@ -365,10 +367,10 @@ fn collect_changes(
                         .insert(entity.entity(), change_tick.this_run());
                 } else {
                     update_message.register_entity();
-                    update_message.end_entity_data()?;
+                    update_message.end_entity_data(false)?;
                 }
 
-                init_message.end_entity_data()?;
+                init_message.end_entity_data(must_init)?;
             }
         }
     }
@@ -451,7 +453,7 @@ fn collect_removals(
                 client_info.ticks.insert(entity, tick);
                 message.write_replication_id(replication_id)?;
             }
-            message.end_entity_data()?;
+            message.end_entity_data(false)?;
         }
     }
     removal_buffer.clear();

--- a/src/server.rs
+++ b/src/server.rs
@@ -332,8 +332,7 @@ fn collect_changes(
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                     let must_init = new_entity || client_info.just_connected;
 
-                    if must_init || ticks.is_added(change_tick.last_run(), change_tick.this_run())
-                    {
+                    if must_init || ticks.is_added(change_tick.last_run(), change_tick.this_run()) {
                         init_message.write_component(
                             &component_info.replication_info,
                             component_info.replication_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -315,7 +315,8 @@ fn collect_changes(
             // If the marker was added in this tick, the entity just started replicating.
             // It could be a newly spawned entity or an old entity with just-enabled replication,
             // so we need to include even old components that were registered for replication.
-            let new_entity = marker_ticks.is_added(change_tick.last_run(), change_tick.this_run());
+            let marker_added =
+                marker_ticks.is_added(change_tick.last_run(), change_tick.this_run());
 
             for component_info in &archetype_info.components {
                 // SAFETY: component and storage were obtained from this archetype.
@@ -330,9 +331,9 @@ fn collect_changes(
                 };
 
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                    let must_init = new_entity || client_info.just_connected;
-
-                    if must_init || ticks.is_added(change_tick.last_run(), change_tick.this_run()) {
+                    let new_entity = marker_added || client_info.just_connected;
+                    if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
+                    {
                         init_message.write_component(
                             &component_info.replication_info,
                             component_info.replication_id,
@@ -355,9 +356,8 @@ fn collect_changes(
             }
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                let must_init = new_entity || client_info.just_connected;
-
-                if must_init || init_message.entity_data_len() != 0 {
+                let new_entity = marker_added || client_info.just_connected;
+                if new_entity || init_message.entity_data_len() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.
                     init_message.take_entity_data(update_message);
@@ -369,7 +369,7 @@ fn collect_changes(
                     update_message.end_entity_data(false)?;
                 }
 
-                init_message.end_entity_data(must_init)?;
+                init_message.end_entity_data(new_entity)?;
             }
         }
     }

--- a/src/server/replication_buffer.rs
+++ b/src/server/replication_buffer.rs
@@ -211,18 +211,17 @@ impl ReplicationBuffer {
     /// See also [`Self::start_array`], [`Self::write_component`] and
     /// [`Self::write_component_id`].
     pub(super) fn end_entity_data(&mut self, save_empty: bool) -> bincode::Result<()> {
-        // abort if empty and unwanted
+        // Abort if empty and unwanted.
         if !save_empty && self.entity_data_len == 0 {
             self.cursor.set_position(self.entity_data_pos);
             return Ok(());
         }
 
-        // add entity if missing
+        // Record entity if it has not been written previously.
         if self.entity_data_len == 0 {
             self.write_data_entity()?;
         }
 
-        // finalize
         let previous_pos = self.cursor.position();
         self.cursor.set_position(self.entity_data_len_pos);
 

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -105,10 +105,7 @@ fn empty_spawn_replication() {
     server_app.update();
     client_app.update();
 
-    assert!(
-        client_app.world.entities().is_empty(),
-        "empty entity shouldn't be replicated"
-    );
+    assert_eq!(client_app.world.entities().len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
This is more robust and facilitates client repair where replicated components are removed from a replicated entity but the entity wasn't despawned.
