### PR TITLE
Replace `Ignored<T>` with `CommandDontReplicateExt::dont_replicate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace `Ignored<T>` with `CommandNotReplicateExt::not_replicate`.
+- Replace `Ignored<T>` with `CommandDontReplicateExt::dont_replicate`.
 - `Replication` entities with no replicated components will now be spawned on the client anyway.
 
 ## [0.18.2] - 2023-12-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ClientSet::Reset` which can be disabled by external users. Also moved the client reset system to `PreUpdate` so clients can react more promptly to resets.
+- `ServerEntityMap::remove_by_client()` for manual client cleanup.
+- `BufferedUpdates`, `ServerEntityTicks` to public API.
+
 ### Changed
 
-- Added `ClientSet::Reset` which can be disabled by external users. Also moved the client reset system to `PreUpdate` so clients can react more promptly to resets.
-- Added `ServerEntityMap::remove_by_client()` for manual client cleanup.
-- Added `BufferedUpdates`, `ServerEntityTicks` to public API.
+- Replace `Ignored<T>` with `CommandNotReplicateExt::not_replicate`.
 - `Replication` entities with no replicated components will now be spawned on the client anyway.
-
 
 ## [0.18.2] - 2023-12-27
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ component. Just insert it to the entity you want to replicate. Only components
 marked for replication through [`AppReplicationExt::replicate()`]
 will be replicated.
 
-If you need to disable replication for specific component for specific entity,
-you can call [`CommandDontReplicateExt::dont_replicate::<T>`] and replication will be skipped for `T`.
+If you need to disable replication for a specific component on an entity,
+you can call [`CommandDontReplicateExt::dont_replicate::<T>`] on it and replication will be skipped for `T`.
 
 ### Tick and fixed timestep games
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ marked for replication through [`AppReplicationExt::replicate()`]
 will be replicated.
 
 If you need to disable replication for specific component for specific entity,
-you can call [`CommandNotReplicateExt::not_replicate::<T>`] and replication will be skipped for `T`.
+you can call [`CommandDontReplicateExt::dont_replicate::<T>`] and replication will be skipped for `T`.
 
 ### Tick and fixed timestep games
 
@@ -422,7 +422,7 @@ pub mod prelude {
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},
         replicon_core::{
-            not_replicate::{CommandNotReplicateExt, EntityNotReplciateExt},
+            dont_replicate::{CommandDontReplicateExt, EntityNotReplciateExt},
             replication_rules::{
                 AppReplicationExt, MapNetworkEntities, Mapper, Replication, ReplicationRules,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ marked for replication through [`AppReplicationExt::replicate()`]
 will be replicated.
 
 If you need to disable replication for specific component for specific entity,
-you can insert [`Ignored<T>`] component and replication will be skipped for `T`.
+you can call [`CommandNotReplicateExt::not_replicate::<T>`] and replication will be skipped for `T`.
 
 ### Tick and fixed timestep games
 
@@ -205,10 +205,6 @@ struct Player;
 This pairs nicely with server state serialization and keeps saves clean.
 You can use [`replicate_into`](scene::replicate_into) to
 fill `DynamicScene` with replicated entities and their components.
-
-The mentioned [`Ignored<T>`] component is an exception.
-It needs to be inserted before [`ServerSet::Send`] in `PostUpdate` on the server.
-So you will need a separate initialization system for it.
 
 ### Component relations
 
@@ -426,9 +422,9 @@ pub mod prelude {
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},
         replicon_core::{
+            not_replicate::{CommandNotReplicateExt, EntityNotReplciateExt},
             replication_rules::{
-                AppReplicationExt, Ignored, MapNetworkEntities, Mapper, Replication,
-                ReplicationRules,
+                AppReplicationExt, MapNetworkEntities, Mapper, Replication, ReplicationRules,
             },
             replicon_tick::RepliconTick,
             NetworkChannels, ReplicationChannel, RepliconCorePlugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ pub mod prelude {
         parent_sync::{ParentSync, ParentSyncPlugin},
         renet::{RenetClient, RenetServer},
         replicon_core::{
-            dont_replicate::{CommandDontReplicateExt, EntityNotReplciateExt},
+            dont_replicate::{CommandDontReplicateExt, EntityDontReplicateExt},
             replication_rules::{
                 AppReplicationExt, MapNetworkEntities, Mapper, Replication, ReplicationRules,
             },

--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -1,3 +1,4 @@
+pub mod not_replicate;
 pub mod replication_rules;
 pub mod replicon_tick;
 

--- a/src/replicon_core.rs
+++ b/src/replicon_core.rs
@@ -1,4 +1,4 @@
-pub mod not_replicate;
+pub mod dont_replicate;
 pub mod replication_rules;
 pub mod replicon_tick;
 

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -40,12 +40,12 @@ impl CommandDontReplicateExt for EntityCommands<'_, '_, '_> {
     }
 }
 
-pub trait EntityNotReplciateExt {
+pub trait EntityDontReplicateExt {
     /// Same as [`CommandDontReplicateExt::dont_replicate`], but for direct use on an entity.
     fn dont_replicate<T: Component>(&mut self) -> &mut Self;
 }
 
-impl EntityNotReplciateExt for EntityWorldMut<'_> {
+impl EntityDontReplicateExt for EntityWorldMut<'_> {
     fn dont_replicate<T: Component>(&mut self) -> &mut Self {
         // SAFETY: world is not mutated and used only to obtain the tick without atomic synchronization.
         let tick = unsafe { self.world_mut().change_tick() };

--- a/src/replicon_core/dont_replicate.rs
+++ b/src/replicon_core/dont_replicate.rs
@@ -9,11 +9,11 @@ pub trait CommandDontReplicateExt {
     /**
     Disables replication for component `T`.
 
-    Should only be called on the entity for which [`Replication`] was inserted at this tick.
+    May only be called on an entity if  [`Replication`] was inserted on it this tick.
 
     # Panics
 
-    Panics if called on an entity without [`Replication`] or if it was inserted on a different tick.
+    Panics if called on an entity without [`Replication`] or if [`Replication`] was inserted in a different tick.
 
     # Examples
 

--- a/src/replicon_core/not_replicate.rs
+++ b/src/replicon_core/not_replicate.rs
@@ -1,0 +1,109 @@
+use core::panic;
+use std::{any, marker::PhantomData};
+
+use bevy::{ecs::system::EntityCommands, prelude::*};
+
+use super::replication_rules::Replication;
+
+pub trait CommandNotReplicateExt {
+    /**
+    Disables replication for component `T`.
+
+    Should only be called on the entity for which [`Replication`] was inserted at this tick.
+
+    # Panics
+
+    Panics if called on an entity without [`Replication`] or if it was inserted on a different tick.
+
+    # Examples
+
+    ```
+    # use bevy::{prelude::*, ecs::system::CommandQueue};
+    # use bevy_replicon::prelude::*;
+    # let mut world = World::new();
+    # let mut queue = CommandQueue::default();
+    # let mut commands = Commands::new(&mut queue, &world);
+    commands.spawn((Replication, Transform::default())).not_replicate::<Transform>();
+    # queue.apply(&mut world);
+    ```
+    */
+    fn not_replicate<T: Component>(&mut self) -> &mut Self;
+}
+
+impl CommandNotReplicateExt for EntityCommands<'_, '_, '_> {
+    fn not_replicate<T: Component>(&mut self) -> &mut Self {
+        self.add(|mut entity: EntityWorldMut| {
+            entity.not_replicate::<T>();
+        });
+
+        self
+    }
+}
+
+pub trait EntityNotReplciateExt {
+    /// Same as [`CommandNotReplicateExt::not_replicate`], but for direct use on an entity.
+    fn not_replicate<T: Component>(&mut self) -> &mut Self;
+}
+
+impl EntityNotReplciateExt for EntityWorldMut<'_> {
+    fn not_replicate<T: Component>(&mut self) -> &mut Self {
+        // SAFETY: world is not mutated and used only to obtain the tick without atomic synchronization.
+        let tick = unsafe { self.world_mut().change_tick() };
+
+        self.insert(NotReplicate::<T>(PhantomData));
+
+        let component_name = any::type_name::<T>();
+        let replication_name = any::type_name::<Replication>();
+        let replication_ticks = self.get_change_ticks::<Replication>().unwrap_or_else(|| {
+            panic!("disabling replication for `{component_name}` should only be done for entities with `{replication_name}`")
+        });
+
+        assert_eq!(
+            tick,
+            replication_ticks.added_tick(),
+            "disabling replication for `{component_name}` should be done only with `{replication_name}` insertion",
+        );
+
+        self
+    }
+}
+
+/// Replication will be ignored for `T` if this component is present on the same entity.
+#[derive(Component, Debug)]
+pub(super) struct NotReplicate<T>(PhantomData<T>);
+
+#[cfg(test)]
+mod tests {
+    use bevy::ecs::system::CommandQueue;
+
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn without_replication() {
+        let mut world = World::new();
+
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+        commands.spawn_empty().not_replicate::<Transform>();
+        queue.apply(&mut world);
+    }
+
+    #[test]
+    #[should_panic]
+    fn after_spawn() {
+        let mut world = World::new();
+
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+        let entity = commands.spawn(Replication).id();
+        queue.apply(&mut world);
+
+        world.increment_change_tick();
+
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+        commands.entity(entity).not_replicate::<Transform>();
+        queue.apply(&mut world);
+    }
+}

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -4,7 +4,7 @@ use bevy::{ecs::component::ComponentId, prelude::*, ptr::Ptr, utils::HashMap};
 use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use super::{not_replicate::NotReplicate, replicon_tick::RepliconTick};
+use super::{dont_replicate::DontReplicate, replicon_tick::RepliconTick};
 use crate::client::client_mapper::{ClientMapper, ServerEntityMap};
 
 pub trait AppReplicationExt {
@@ -66,9 +66,9 @@ impl AppReplicationExt for App {
         C: Component,
     {
         let component_id = self.world.init_component::<C>();
-        let not_replicate_id = self.world.init_component::<NotReplicate<C>>();
+        let dont_replicate_id = self.world.init_component::<DontReplicate<C>>();
         let replicated_component = ReplicationInfo {
-            not_replicate_id,
+            dont_replicate_id,
             serialize,
             deserialize,
             remove,
@@ -169,8 +169,8 @@ pub type EntityDespawnFn = fn(EntityWorldMut, RepliconTick);
 /// Stores meta information about replicated component.
 #[derive(Clone)]
 pub(crate) struct ReplicationInfo {
-    /// ID of [`NotReplicate<T>`] component.
-    pub(crate) not_replicate_id: ComponentId,
+    /// ID of [`DontReplicate<T>`] component.
+    pub(crate) dont_replicate_id: ComponentId,
 
     /// Function that serializes component into bytes.
     pub(crate) serialize: SerializeFn,

--- a/src/replicon_core/replication_rules.rs
+++ b/src/replicon_core/replication_rules.rs
@@ -1,17 +1,16 @@
-use std::{io::Cursor, marker::PhantomData};
+use std::io::Cursor;
 
 use bevy::{ecs::component::ComponentId, prelude::*, ptr::Ptr, utils::HashMap};
 use bincode::{DefaultOptions, Options};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use super::replicon_tick::RepliconTick;
+use super::{not_replicate::NotReplicate, replicon_tick::RepliconTick};
 use crate::client::client_mapper::{ClientMapper, ServerEntityMap};
 
 pub trait AppReplicationExt {
     /// Marks component for replication.
     ///
     /// Component will be serialized as is using bincode.
-    /// It also registers [`Ignored<T>`] that can be used to exclude the component from replication.
     fn replicate<C>(&mut self) -> &mut Self
     where
         C: Component + Serialize + DeserializeOwned;
@@ -67,9 +66,9 @@ impl AppReplicationExt for App {
         C: Component,
     {
         let component_id = self.world.init_component::<C>();
-        let ignored_id = self.world.init_component::<Ignored<C>>();
+        let not_replicate_id = self.world.init_component::<NotReplicate<C>>();
         let replicated_component = ReplicationInfo {
-            ignored_id,
+            not_replicate_id,
             serialize,
             deserialize,
             remove,
@@ -170,8 +169,8 @@ pub type EntityDespawnFn = fn(EntityWorldMut, RepliconTick);
 /// Stores meta information about replicated component.
 #[derive(Clone)]
 pub(crate) struct ReplicationInfo {
-    /// ID of [`Ignored<T>`] component.
-    pub(crate) ignored_id: ComponentId,
+    /// ID of [`NotReplicate<T>`] component.
+    pub(crate) not_replicate_id: ComponentId,
 
     /// Function that serializes component into bytes.
     pub(crate) serialize: SerializeFn,
@@ -187,16 +186,6 @@ pub(crate) struct ReplicationInfo {
 #[derive(Component, Clone, Copy, Default, Reflect, Debug)]
 #[reflect(Component)]
 pub struct Replication;
-
-/// Replication will be ignored for `T` if this component is present on the same entity.
-#[derive(Component, Debug)]
-pub struct Ignored<T>(PhantomData<T>);
-
-impl<T> Default for Ignored<T> {
-    fn default() -> Self {
-        Self(PhantomData)
-    }
-}
 
 /// Same as [`ComponentId`], but consistent between server and clients.
 ///

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -71,7 +71,7 @@ pub fn replicate_into(scene: &mut DynamicScene, world: &World) {
             let Some((_, replication_info)) = replication_rules.get(component_id) else {
                 continue;
             };
-            if archetype.contains(replication_info.ignored_id) {
+            if archetype.contains(replication_info.not_replicate_id) {
                 continue;
             }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -71,7 +71,7 @@ pub fn replicate_into(scene: &mut DynamicScene, world: &World) {
             let Some((_, replication_info)) = replication_rules.get(component_id) else {
                 continue;
             };
-            if archetype.contains(replication_info.not_replicate_id) {
+            if archetype.contains(replication_info.dont_replicate_id) {
                 continue;
             }
 

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -39,7 +39,7 @@ impl ReplicatedArchetypesInfo {
                 else {
                     continue;
                 };
-                if archetype.contains(replication_info.not_replicate_id) {
+                if archetype.contains(replication_info.dont_replicate_id) {
                     continue;
                 }
 

--- a/src/server/replicated_archetypes_info.rs
+++ b/src/server/replicated_archetypes_info.rs
@@ -39,7 +39,7 @@ impl ReplicatedArchetypesInfo {
                 else {
                     continue;
                 };
-                if archetype.contains(replication_info.ignored_id) {
+                if archetype.contains(replication_info.not_replicate_id) {
                     continue;
                 }
 

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -255,7 +255,7 @@ fn insert_replication() {
         ))
         .replicate::<TableComponent>()
         .replicate::<SparseSetComponent>()
-        .replicate::<IgnoredComponent>()
+        .replicate::<NotReplicatedComponent>()
         .replicate_mapped::<MappedComponent>();
     }
 
@@ -276,9 +276,9 @@ fn insert_replication() {
             SparseSetComponent,
             NonReplicatingComponent,
             MappedComponent(server_map_entity),
-            IgnoredComponent,
-            Ignored::<IgnoredComponent>::default(),
+            NotReplicatedComponent,
         ))
+        .not_replicate::<NotReplicatedComponent>()
         .id();
 
     let mut entity_map = client_app.world.resource_mut::<ServerEntityMap>();
@@ -292,7 +292,7 @@ fn insert_replication() {
     assert!(client_entity.contains::<SparseSetComponent>());
     assert!(client_entity.contains::<TableComponent>());
     assert!(!client_entity.contains::<NonReplicatingComponent>());
-    assert!(!client_entity.contains::<IgnoredComponent>());
+    assert!(!client_entity.contains::<NotReplicatedComponent>());
     assert_eq!(
         client_entity.get::<MappedComponent>().unwrap().0,
         client_map_entity
@@ -763,11 +763,8 @@ fn replication_into_scene() {
     let reflect_entity = app.world.spawn((Replication, ReflectedComponent)).id();
     let empty_entity = app
         .world
-        .spawn((
-            Replication,
-            ReflectedComponent,
-            Ignored::<ReflectedComponent>::default(),
-        ))
+        .spawn((Replication, ReflectedComponent))
+        .not_replicate::<ReflectedComponent>()
         .id();
 
     let mut scene = DynamicScene::default();
@@ -862,7 +859,7 @@ struct SparseSetComponent;
 struct NonReplicatingComponent;
 
 #[derive(Component, Deserialize, Serialize)]
-struct IgnoredComponent;
+struct NotReplicatedComponent;
 
 #[derive(Clone, Component, Copy, Deserialize, Serialize)]
 struct BoolComponent(bool);

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -278,7 +278,7 @@ fn insert_replication() {
             MappedComponent(server_map_entity),
             NotReplicatedComponent,
         ))
-        .not_replicate::<NotReplicatedComponent>()
+        .dont_replicate::<NotReplicatedComponent>()
         .id();
 
     let mut entity_map = client_app.world.resource_mut::<ServerEntityMap>();
@@ -764,7 +764,7 @@ fn replication_into_scene() {
     let empty_entity = app
         .world
         .spawn((Replication, ReflectedComponent))
-        .not_replicate::<ReflectedComponent>()
+        .dont_replicate::<ReflectedComponent>()
         .id();
 
     let mut scene = DynamicScene::default();


### PR DESCRIPTION
Now `Ignored<T>` is private and renamed into `DontReplicate<T>`. Now `CommandDontReplicateExt::dont_replicate` should be used instead.
I did this to avoid letting users delete and insert this component dynamically.

Suggestions are welcome, especially about docs and naming.