### PR TITLE
Refactor benches and connection helpers to measure multiple clients

### DIFF
--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -13,31 +13,105 @@ use spin_sleep::{SpinSleeper, SpinStrategy};
 struct DummyComponent(usize);
 
 fn replication(c: &mut Criterion) {
-    const ENTITIES: u32 = 900;
+    const ENTITIES: u32 = 1000;
     const SOCKET_WAIT: Duration = Duration::from_millis(5); // Sometimes it takes time for socket to receive all data.
 
     // Use spinner to keep CPU hot in the schedule for stable benchmark results.
     let sleeper = SpinSleeper::new(1_000_000_000).with_spin_strategy(SpinStrategy::SpinLoopHint);
 
-    c.bench_function("entities send", |b| {
+    for clients in [1, 20] {
+        c.bench_function(&format!("init send, {clients} client(s)"), |b| {
+            b.iter_custom(|iter| {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iter {
+                    let mut server_app = create_app();
+                    let mut client_apps = Vec::new();
+                    for _ in 0..clients {
+                        client_apps.push(create_app());
+                    }
+                    common::connect_multiple(&mut server_app, &mut client_apps);
+
+                    server_app
+                        .world
+                        .spawn_batch([(Replication, DummyComponent(0)); ENTITIES as usize]);
+
+                    let instant = Instant::now();
+                    server_app.update();
+                    elapsed += instant.elapsed();
+
+                    sleeper.sleep(SOCKET_WAIT);
+                    for app in &mut client_apps {
+                        app.update();
+                        assert_eq!(app.world.entities().len(), ENTITIES);
+                    }
+                }
+
+                elapsed
+            })
+        });
+
+        c.bench_function(&format!("update send, {clients} client(s)"), |b| {
+            b.iter_custom(|iter| {
+                let mut server_app = create_app();
+                let mut client_apps = Vec::new();
+                for _ in 0..clients {
+                    client_apps.push(create_app());
+                }
+                common::connect_multiple(&mut server_app, &mut client_apps);
+
+                server_app
+                    .world
+                    .spawn_batch([(Replication, DummyComponent(0)); ENTITIES as usize]);
+                let mut query = server_app.world.query::<&mut DummyComponent>();
+
+                server_app.update();
+                sleeper.sleep(SOCKET_WAIT);
+                for app in &mut client_apps {
+                    app.update();
+                    assert_eq!(app.world.entities().len(), ENTITIES);
+                }
+
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iter {
+                    for mut dummy_component in query.iter_mut(&mut server_app.world) {
+                        dummy_component.0 += 1;
+                    }
+
+                    sleeper.sleep(SOCKET_WAIT);
+                    let instant = Instant::now();
+                    server_app.update();
+                    elapsed += instant.elapsed();
+
+                    sleeper.sleep(SOCKET_WAIT);
+                    for app in &mut client_apps {
+                        app.update();
+                        assert_eq!(app.world.entities().len(), ENTITIES);
+                    }
+                }
+
+                elapsed
+            })
+        });
+    }
+
+    c.bench_function("init receive", |b| {
         b.iter_custom(|iter| {
             let mut elapsed = Duration::ZERO;
             for _ in 0..iter {
-                let mut server_app = App::new();
-                let mut client_app = App::new();
-                setup_apps(&mut server_app, &mut client_app);
+                let mut server_app = create_app();
+                let mut client_app = create_app();
                 common::connect(&mut server_app, &mut client_app);
 
                 server_app
                     .world
                     .spawn_batch([(Replication, DummyComponent(0)); ENTITIES as usize]);
 
-                let instant = Instant::now();
                 server_app.update();
-                elapsed += instant.elapsed();
-
                 sleeper.sleep(SOCKET_WAIT);
+
+                let instant = Instant::now();
                 client_app.update();
+                elapsed += instant.elapsed();
                 assert_eq!(client_app.world.entities().len(), ENTITIES);
             }
 
@@ -45,37 +119,10 @@ fn replication(c: &mut Criterion) {
         })
     });
 
-    c.bench_function("entities receive", |b| {
+    c.bench_function("update receive", |b| {
         b.iter_custom(|iter| {
-            let mut elapsed = Duration::ZERO;
-            for _ in 0..iter {
-                let mut server_app = App::new();
-                let mut client_app = App::new();
-                setup_apps(&mut server_app, &mut client_app);
-                common::connect(&mut server_app, &mut client_app);
-
-                server_app
-                    .world
-                    .spawn_batch([(Replication, DummyComponent(0)); ENTITIES as usize]);
-
-                server_app.update();
-                sleeper.sleep(SOCKET_WAIT);
-
-                let instant = Instant::now();
-                client_app.update();
-                elapsed += instant.elapsed();
-                assert_eq!(client_app.world.entities().len(), ENTITIES);
-            }
-
-            elapsed
-        })
-    });
-
-    c.bench_function("entities update send", |b| {
-        b.iter_custom(|iter| {
-            let mut server_app = App::new();
-            let mut client_app = App::new();
-            setup_apps(&mut server_app, &mut client_app);
+            let mut server_app = create_app();
+            let mut client_app = create_app();
             common::connect(&mut server_app, &mut client_app);
 
             server_app
@@ -95,47 +142,11 @@ fn replication(c: &mut Criterion) {
                 }
 
                 sleeper.sleep(SOCKET_WAIT);
-                let instant = Instant::now();
-                server_app.update();
-                elapsed += instant.elapsed();
-
-                sleeper.sleep(SOCKET_WAIT);
-                client_app.update();
-                assert_eq!(client_app.world.entities().len(), ENTITIES);
-            }
-
-            elapsed
-        })
-    });
-
-    c.bench_function("entities update receive", |b| {
-        b.iter_custom(|iter| {
-            let mut server_app = App::new();
-            let mut client_app = App::new();
-            setup_apps(&mut server_app, &mut client_app);
-            common::connect(&mut server_app, &mut client_app);
-
-            server_app
-                .world
-                .spawn_batch([(Replication, DummyComponent(0)); ENTITIES as usize]);
-            let mut query = server_app.world.query::<&mut DummyComponent>();
-
-            server_app.update();
-            sleeper.sleep(SOCKET_WAIT);
-            client_app.update();
-            assert_eq!(client_app.world.entities().len(), ENTITIES);
-
-            let mut elapsed = Duration::ZERO;
-            for _ in 0..iter {
-                for mut dummy_component in query.iter_mut(&mut server_app.world) {
-                    dummy_component.0 += 1;
-                }
-
-                sleeper.sleep(SOCKET_WAIT);
                 server_app.update();
                 sleeper.sleep(SOCKET_WAIT);
 
                 let instant = Instant::now();
+
                 client_app.update();
                 elapsed += instant.elapsed();
                 assert_eq!(client_app.world.entities().len(), ENTITIES);
@@ -146,17 +157,18 @@ fn replication(c: &mut Criterion) {
     });
 }
 
-fn setup_apps(server_app: &mut App, client_app: &mut App) {
-    for app in [server_app, client_app] {
-        app.add_plugins((
-            MinimalPlugins,
-            ReplicationPlugins.set(ServerPlugin {
-                tick_policy: TickPolicy::EveryFrame,
-                ..Default::default()
-            }),
-        ))
-        .replicate::<DummyComponent>();
-    }
+fn create_app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        ReplicationPlugins.set(ServerPlugin {
+            tick_policy: TickPolicy::EveryFrame,
+            ..Default::default()
+        }),
+    ))
+    .replicate::<DummyComponent>();
+
+    app
 }
 
 criterion_group! {

--- a/benches/replication.rs
+++ b/benches/replication.rs
@@ -1,5 +1,5 @@
-#[path = "../tests/common/mod.rs"]
-mod common;
+#[path = "../tests/connect/mod.rs"]
+mod connect;
 
 use std::time::{Duration, Instant};
 
@@ -29,7 +29,7 @@ fn replication(c: &mut Criterion) {
                     for _ in 0..clients {
                         client_apps.push(create_app());
                     }
-                    common::connect_multiple(&mut server_app, &mut client_apps);
+                    connect::multiple_clients(&mut server_app, &mut client_apps);
 
                     server_app
                         .world
@@ -57,7 +57,7 @@ fn replication(c: &mut Criterion) {
                 for _ in 0..clients {
                     client_apps.push(create_app());
                 }
-                common::connect_multiple(&mut server_app, &mut client_apps);
+                connect::multiple_clients(&mut server_app, &mut client_apps);
 
                 server_app
                     .world
@@ -100,7 +100,7 @@ fn replication(c: &mut Criterion) {
             for _ in 0..iter {
                 let mut server_app = create_app();
                 let mut client_app = create_app();
-                common::connect(&mut server_app, &mut client_app);
+                connect::single_client(&mut server_app, &mut client_app);
 
                 server_app
                     .world
@@ -123,7 +123,7 @@ fn replication(c: &mut Criterion) {
         b.iter_custom(|iter| {
             let mut server_app = create_app();
             let mut client_app = create_app();
-            common::connect(&mut server_app, &mut client_app);
+            connect::single_client(&mut server_app, &mut client_app);
 
             server_app
                 .world

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -1,4 +1,4 @@
-mod common;
+mod connect;
 
 use bevy::{ecs::event::Events, prelude::*, time::TimePlugin};
 use bevy_replicon::prelude::*;
@@ -35,7 +35,7 @@ fn sending_receiving() {
             .add_client_event::<DummyEvent>(EventType::Ordered);
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     client_app
         .world
@@ -60,7 +60,7 @@ fn mapping_and_sending_receiving() {
             .add_mapped_client_event::<MappedEvent>(EventType::Ordered);
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let client_entity = Entity::from_raw(0);
     let server_entity = Entity::from_raw(client_entity.index() + 1);

--- a/tests/client_event.rs
+++ b/tests/client_event.rs
@@ -2,8 +2,7 @@ mod common;
 
 use bevy::{ecs::event::Events, prelude::*, time::TimePlugin};
 use bevy_replicon::prelude::*;
-
-use common::DummyEvent;
+use serde::{Deserialize, Serialize};
 
 #[test]
 fn without_server_plugin() {
@@ -41,7 +40,7 @@ fn sending_receiving() {
     client_app
         .world
         .resource_mut::<Events<DummyEvent>>()
-        .send(DummyEvent(Entity::PLACEHOLDER));
+        .send(DummyEvent);
 
     client_app.update();
     server_app.update();
@@ -58,7 +57,7 @@ fn mapping_and_sending_receiving() {
     let mut client_app = App::new();
     for app in [&mut server_app, &mut client_app] {
         app.add_plugins((MinimalPlugins, ReplicationPlugins))
-            .add_mapped_client_event::<DummyEvent>(EventType::Ordered);
+            .add_mapped_client_event::<MappedEvent>(EventType::Ordered);
     }
 
     common::connect(&mut server_app, &mut client_app);
@@ -72,15 +71,15 @@ fn mapping_and_sending_receiving() {
 
     client_app
         .world
-        .resource_mut::<Events<DummyEvent>>()
-        .send(DummyEvent(client_entity));
+        .resource_mut::<Events<MappedEvent>>()
+        .send(MappedEvent(client_entity));
 
     client_app.update();
     server_app.update();
 
     let mapped_entities: Vec<_> = server_app
         .world
-        .resource_mut::<Events<FromClient<DummyEvent>>>()
+        .resource_mut::<Events<FromClient<MappedEvent>>>()
         .drain()
         .map(|event| event.event.0)
         .collect();
@@ -95,7 +94,7 @@ fn local_resending() {
 
     app.world
         .resource_mut::<Events<DummyEvent>>()
-        .send(DummyEvent(Entity::PLACEHOLDER));
+        .send(DummyEvent);
 
     app.update();
 
@@ -104,4 +103,16 @@ fn local_resending() {
 
     let client_events = app.world.resource::<Events<FromClient<DummyEvent>>>();
     assert_eq!(client_events.len(), 1);
+}
+
+#[derive(Deserialize, Event, Serialize)]
+struct DummyEvent;
+
+#[derive(Deserialize, Event, Serialize)]
+struct MappedEvent(Entity);
+
+impl MapNetworkEntities for MappedEvent {
+    fn map_entities<T: Mapper>(&mut self, mapper: &mut T) {
+        self.0 = mapper.map(self.0);
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,7 +12,6 @@ use bevy_renet::renet::{
     ConnectionConfig, RenetClient, RenetServer,
 };
 use bevy_replicon::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub(super) fn connect(server_app: &mut App, client_app: &mut App) {
     const CLIENT_ID: u64 = 1;
@@ -113,13 +112,4 @@ fn create_client_transport(client_id: u64, port: u16) -> NetcodeClientTransport 
     };
 
     NetcodeClientTransport::new(current_time, authentication, socket).unwrap()
-}
-
-#[derive(Deserialize, Event, Serialize)]
-pub(super) struct DummyEvent(pub(super) Entity);
-
-impl MapNetworkEntities for DummyEvent {
-    fn map_entities<T: Mapper>(&mut self, mapper: &mut T) {
-        self.0 = mapper.map(self.0);
-    }
 }

--- a/tests/connect/mod.rs
+++ b/tests/connect/mod.rs
@@ -13,7 +13,7 @@ use bevy_renet::renet::{
 };
 use bevy_replicon::prelude::*;
 
-pub(super) fn connect(server_app: &mut App, client_app: &mut App) {
+pub(super) fn single_client(server_app: &mut App, client_app: &mut App) {
     const CLIENT_ID: u64 = 1;
     let port = setup_server(server_app, 1);
     setup_client(client_app, CLIENT_ID, port);
@@ -21,7 +21,7 @@ pub(super) fn connect(server_app: &mut App, client_app: &mut App) {
 }
 
 #[allow(dead_code)]
-pub(super) fn connect_multiple(server_app: &mut App, client_apps: &mut [App]) {
+pub(super) fn multiple_clients(server_app: &mut App, client_apps: &mut [App]) {
     const BASE_ID: u64 = 1;
     let port = setup_server(server_app, client_apps.len());
     for (index, client_app) in client_apps.iter_mut().enumerate() {

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -1,4 +1,4 @@
-mod common;
+mod connect;
 
 use std::ops::DerefMut;
 
@@ -25,7 +25,7 @@ fn reset() {
         ));
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     client_app.world.resource_mut::<RenetClient>().disconnect();
 
@@ -60,7 +60,7 @@ fn spawn_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
 
@@ -98,7 +98,7 @@ fn empty_spawn_replication() {
         ));
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     server_app.world.spawn(Replication);
 
@@ -123,7 +123,7 @@ fn old_spawn_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     // Spawn an entity with replicated component, but without a marker.
     let server_entity = server_app.world.spawn(TableComponent).id();
@@ -166,7 +166,7 @@ fn before_connection_spawn_replication() {
     // Spawn an entity before client connected.
     server_app.world.spawn((Replication, TableComponent));
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     client_app
         .world
@@ -189,7 +189,7 @@ fn client_spawn_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     // Make client and server have different entity IDs.
     server_app.world.spawn_empty();
@@ -259,7 +259,7 @@ fn insert_replication() {
         .replicate_mapped::<MappedComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     // Make client and server have different entity IDs.
     server_app.world.spawn_empty();
@@ -313,7 +313,7 @@ fn despawn_replication() {
         ));
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_child_entity = server_app.world.spawn(Replication).id();
     let server_entity = server_app
@@ -364,7 +364,7 @@ fn removal_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -411,7 +411,7 @@ fn update_replication() {
         .replicate::<BoolComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -452,7 +452,7 @@ fn big_entity_update_replication() {
         .replicate::<VecComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -495,7 +495,7 @@ fn many_entities_update_replication() {
         .replicate::<BoolComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     // Spawn many entities to cover message splitting.
     const ENTITIES_COUNT: u32 = 300;
@@ -544,7 +544,7 @@ fn insert_update_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -584,7 +584,7 @@ fn despawn_update_replication() {
         .replicate::<TableComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -626,7 +626,7 @@ fn update_replication_buffering() {
         .replicate::<BoolComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -683,7 +683,7 @@ fn update_replication_cleanup() {
         .replicate::<BoolComponent>();
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let server_entity = server_app
         .world
@@ -799,7 +799,7 @@ fn diagnostics() {
     }
     client_app.add_plugins(ClientDiagnosticsPlugin);
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let client_entity = client_app.world.spawn_empty().id();
     let server_entity = server_app.world.spawn((Replication, TableComponent)).id();

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -1,4 +1,4 @@
-mod common;
+mod connect;
 
 use bevy::{ecs::event::Events, prelude::*, time::TimePlugin};
 use bevy_renet::renet::{transport::NetcodeClientTransport, ClientId};
@@ -43,7 +43,7 @@ fn sending_receiving() {
         .add_server_event::<DummyEvent>(EventType::Ordered);
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
@@ -90,7 +90,7 @@ fn sending_receiving_and_mapping() {
         .add_mapped_server_event::<MappedEvent>(EventType::Ordered);
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     let client_entity = Entity::from_raw(0);
     let server_entity = Entity::from_raw(client_entity.index() + 1);
@@ -176,7 +176,7 @@ fn event_queue() {
         .add_server_event::<DummyEvent>(EventType::Ordered);
     }
 
-    common::connect(&mut server_app, &mut client_app);
+    connect::single_client(&mut server_app, &mut client_app);
 
     // Spawn entity to trigger world change.
     server_app.world.spawn((Replication, DummyComponent));


### PR DESCRIPTION
I would recommend to read this PR commit by commit.

In this PR I parametrized send benchmarks to run with 1 and 20 clients. Necessary to properly benchmark #149.

In order to achieve it I refactored connection helper. There are two functions now: for single client and for multiple clients that reuse more granular private helpers under the hood.

I also moved `DummyEvent` from `common` into event tests and split it into `DummyEvent` without field and `MappedEvent` for clarity.

And lastly I renamed `common` into `connect` since all helpers are related to connection.