### PR TITLE
Don't panic if the server sends a duplicate mapping

### DIFF
--- a/src/client/client_mapper.rs
+++ b/src/client/client_mapper.rs
@@ -54,7 +54,11 @@ impl ServerEntityMap {
     #[inline]
     pub fn insert(&mut self, server_entity: Entity, client_entity: Entity) {
         if let Some(existing_entity) = self.server_to_client.insert(server_entity, client_entity) {
-            panic!("mapping {server_entity:?} to {client_entity:?}, but it's already mapped to {existing_entity:?}");
+            if client_entity != existing_entity {
+                panic!("mapping {server_entity:?} to {client_entity:?}, but it's already mapped to {existing_entity:?}");
+            } else {
+                warn!("received duplicate mapping from {server_entity:?} to {client_entity:?}");
+            }
         }
         self.client_to_server.insert(client_entity, server_entity);
     }


### PR DESCRIPTION
I encountered this in `bevy_replicon_repair`. After a reconnect if you resend a mapping that was already successfully sent, it panics.