### PR TITLE
Move server event reset system to ClientSet::ResetEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved server event reset system to `ClientSet::Reset`.
+
 ## [0.19.0] - 2024-01-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved server event reset system to `ClientSet::Reset`.
+- Moved server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.
 
 ## [0.19.0] - 2024-01-07
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -495,7 +495,7 @@ pub enum ClientSet {
     ///
     /// This is a separate set from `ClientSet::Reset` in case you want to enable/disable it separately.
     /// In general it is best practice to clear queued server events after a disconnect, whereas you may want to
-    /// preserve replication state (in which cse `ClientSet::Reset` should be disabled).
+    /// preserve replication state (in which case `ClientSet::Reset` should be disabled).
     ResetEvents,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,6 +36,12 @@ impl Plugin for ClientPlugin {
                     .run_if(bevy_renet::client_just_disconnected()),
             )
             .configure_sets(
+                PreUpdate,
+                ClientSet::ResetEvents
+                    .after(NetcodeClientPlugin::update_system)
+                    .run_if(bevy_renet::client_just_disconnected()),
+            )
+            .configure_sets(
                 PostUpdate,
                 ClientSet::Send.before(NetcodeClientPlugin::send_packets),
             )
@@ -483,6 +489,14 @@ pub enum ClientSet {
     /// If this set is disabled, then you need to manually clean up the client after a disconnect or when
     /// reconnecting.
     Reset,
+    /// Systems that reset queued server events.
+    ///
+    /// Runs in `PreUpdate`.
+    ///
+    /// This is a separate set from `ClientSet::Reset` in case you want to enable/disable it separately.
+    /// In general it is best practice to clear queued server events after a disconnect, whereas you may want to
+    /// preserve replication state (in which cse `ClientSet::Reset` should be disabled).
+    ResetEvents,
 }
 
 /// Last received tick for each entity.

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -184,13 +184,13 @@ impl ServerEventAppExt for App {
             .add_systems(PreUpdate, reset_system::<T>.in_set(ClientSet::Reset))
             .add_systems(
                 PostUpdate,
-                ((
+                (
                     sending_system.run_if(resource_exists::<RenetServer>()),
                     local_resending_system::<T>.run_if(has_authority()),
                 )
                     .chain()
                     .after(ServerPlugin::replication_sending_system)
-                    .in_set(ServerSet::Send),),
+                    .in_set(ServerSet::Send),
             );
 
         self

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -184,15 +184,13 @@ impl ServerEventAppExt for App {
             .add_systems(PreUpdate, reset_system::<T>.in_set(ClientSet::Reset))
             .add_systems(
                 PostUpdate,
-                (
-                    (
-                        sending_system.run_if(resource_exists::<RenetServer>()),
-                        local_resending_system::<T>.run_if(has_authority()),
-                    )
-                        .chain()
-                        .after(ServerPlugin::replication_sending_system)
-                        .in_set(ServerSet::Send),
-                ),
+                ((
+                    sending_system.run_if(resource_exists::<RenetServer>()),
+                    local_resending_system::<T>.run_if(has_authority()),
+                )
+                    .chain()
+                    .after(ServerPlugin::replication_sending_system)
+                    .in_set(ServerSet::Send),),
             );
 
         self

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -181,6 +181,7 @@ impl ServerEventAppExt for App {
                     .in_set(ClientSet::Receive)
                     .run_if(client_connected()),
             )
+            .add_systems(PreUpdate, reset_system::<T>.in_set(ClientSet::Reset))
             .add_systems(
                 PostUpdate,
                 (
@@ -191,7 +192,6 @@ impl ServerEventAppExt for App {
                         .chain()
                         .after(ServerPlugin::replication_sending_system)
                         .in_set(ServerSet::Send),
-                    reset_system::<T>.run_if(resource_removed::<RenetClient>()),
                 ),
             );
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -181,7 +181,7 @@ impl ServerEventAppExt for App {
                     .in_set(ClientSet::Receive)
                     .run_if(client_connected()),
             )
-            .add_systems(PreUpdate, reset_system::<T>.in_set(ClientSet::Reset))
+            .add_systems(PreUpdate, reset_system::<T>.in_set(ClientSet::ResetEvents))
             .add_systems(
                 PostUpdate,
                 (


### PR DESCRIPTION
We don't want old server messages to leak across a reconnect. This isn't a complete solution since bevy `Event` queues are not cleaned up every tick, but it's at least more correct.

I put the reset system in a new client set to make it easier to use with `bevy_replicon_repair`.