### PR TITLE
GIve ServerEventQueue an explicit interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor `ServerEventQueue` to have an explicit interface.
+
 ## [0.19.0] - 2024-01-07
 
 ### Added

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -348,17 +348,23 @@ pub enum SendMode {
 pub struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
 
 impl<T> ServerEventQueue<T> {
+    /// Clears the event queue.
     pub fn clear(&mut self) {
         self.0.clear();
     }
 
+    /// Inserts a new event.
+    ///
+    /// The event will be queued until [`Self::pop_next`] is called with a replicon tick >= the tick specified here,
+    /// or until [`Self::clear`] is called.
+    pub fn insert(&mut self, tick: RepliconTick, event: T) {
+        self.0.insert(tick, event);
+    }
+
+    /// Pops the next event that is at least as old as the specified replicon tick.
     pub fn pop_next(&mut self, replicon_tick: RepliconTick) -> Option<T> {
         self.0.front().filter(|(&tick, _)| tick <= replicon_tick)?;
         self.0.pop_front().map(|(_, event)| event)
-    }
-
-    pub fn insert(&mut self, tick: RepliconTick, event: T) {
-        self.0.insert(tick, event);
     }
 }
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -353,15 +353,7 @@ impl<T> ServerEventQueue<T> {
     }
 
     pub fn pop_next(&mut self, replicon_tick: RepliconTick) -> Option<T> {
-        if self
-            .0
-            .front()
-            .filter(|(&tick, _)| tick <= replicon_tick)
-            .is_none()
-        {
-            return None;
-        }
-
+        self.0.front().filter(|(&tick, _)| tick <= replicon_tick)?;
         self.0.pop_front().map(|(_, event)| event)
     }
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -205,12 +205,7 @@ fn queue_system<T: Event>(
     mut server_events: EventWriter<T>,
     mut event_queue: ResMut<ServerEventQueue<T>>,
 ) {
-    while event_queue
-        .front()
-        .filter(|(&tick, _)| tick <= *replicon_tick)
-        .is_some()
-    {
-        let (_, event) = event_queue.pop_front().unwrap();
+    while let Some(event) = event_queue.pop_next(*replicon_tick) {
         server_events.send(event);
     }
 }
@@ -349,8 +344,31 @@ pub enum SendMode {
 ///
 /// Stores data sorted by ticks and maintains order of arrival.
 /// Needed to ensure that when an event is triggered, all the data that it affects or references already exists.
-#[derive(Deref, DerefMut, Resource)]
+#[derive(Resource)]
 pub struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
+
+impl<T> ServerEventQueue<T> {
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn pop_next(&mut self, replicon_tick: RepliconTick) -> Option<T> {
+        if self
+            .0
+            .front()
+            .filter(|(&tick, _)| tick <= replicon_tick)
+            .is_none()
+        {
+            return None;
+        }
+
+        self.0.pop_front().map(|(_, event)| event)
+    }
+
+    pub fn insert(&mut self, tick: RepliconTick, event: T) {
+        self.0.insert(tick, event);
+    }
+}
 
 impl<T> Default for ServerEventQueue<T> {
     fn default() -> Self {

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -363,7 +363,10 @@ impl<T> ServerEventQueue<T> {
 
     /// Pops the next event that is at least as old as the specified replicon tick.
     pub fn pop_next(&mut self, replicon_tick: RepliconTick) -> Option<T> {
-        self.0.front().filter(|(&tick, _)| tick <= replicon_tick)?;
+        let (tick, _) = self.0.front()?;
+        if *tick > replicon_tick {
+            return None;
+        }
         self.0.pop_front().map(|(_, event)| event)
     }
 }


### PR DESCRIPTION
This makes it easier to use the queue outside this crate.