### PR TITLE
Hide extra functionality from `ServerEventQueue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Refactor `ServerEventQueue` to have an explicit interface.
+- Hide extra functionality from `ServerEventQueue`.
 - Moved server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.
 
 ## [0.19.0] - 2024-01-07

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -203,13 +203,7 @@ fn queue_system<T: Event>(
     mut server_events: EventWriter<T>,
     mut event_queue: ResMut<ServerEventQueue<T>>,
 ) {
-    while event_queue
-        .0
-        .front()
-        .filter(|(&tick, _)| tick <= *replicon_tick)
-        .is_some()
-    {
-        let (_, event) = event_queue.0.pop_front().unwrap();
+    while let Some(event) = event_queue.try_pop(*replicon_tick) {
         server_events.send(event);
     }
 }
@@ -354,9 +348,18 @@ pub struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
 impl<T> ServerEventQueue<T> {
     /// Inserts a new event.
     ///
-    /// The event will be queued until [`RepliconTick`] will be bigger or equal to the tick specified here.
+    /// The event will be queued until [`RepliconTick`] is bigger or equal to the tick specified here.
     pub fn insert(&mut self, tick: RepliconTick, event: T) {
         self.0.insert(tick, event);
+    }
+
+    /// Pops the next event that is at least as old as the specified replicon tick.
+    pub fn try_pop(&mut self, replicon_tick: RepliconTick) -> Option<T> {
+        let (tick, _) = self.0.front()?;
+        if *tick > replicon_tick {
+            return None;
+        }
+        self.0.pop_front().map(|(_, event)| event)
     }
 }
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -354,7 +354,7 @@ impl<T> ServerEventQueue<T> {
     }
 
     /// Pops the next event that is at least as old as the specified replicon tick.
-    pub fn try_pop(&mut self, replicon_tick: RepliconTick) -> Option<T> {
+    fn try_pop(&mut self, replicon_tick: RepliconTick) -> Option<T> {
         let (tick, _) = self.0.front()?;
         if *tick > replicon_tick {
             return None;

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -203,7 +203,13 @@ fn queue_system<T: Event>(
     mut server_events: EventWriter<T>,
     mut event_queue: ResMut<ServerEventQueue<T>>,
 ) {
-    while let Some(event) = event_queue.pop_next(*replicon_tick) {
+    while event_queue
+        .0
+        .front()
+        .filter(|(&tick, _)| tick <= *replicon_tick)
+        .is_some()
+    {
+        let (_, event) = event_queue.0.pop_front().unwrap();
         server_events.send(event);
     }
 }
@@ -291,7 +297,7 @@ fn local_resending_system<T: Event>(
 }
 
 fn reset_system<T: Event>(mut event_queue: ResMut<ServerEventQueue<T>>) {
-    event_queue.clear();
+    event_queue.0.clear();
 }
 
 /// Sends serialized `message` to clients.
@@ -346,26 +352,11 @@ pub enum SendMode {
 pub struct ServerEventQueue<T>(ListOrderedMultimap<RepliconTick, T>);
 
 impl<T> ServerEventQueue<T> {
-    /// Clears the event queue.
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-
     /// Inserts a new event.
     ///
-    /// The event will be queued until [`Self::pop_next`] is called with a replicon tick >= the tick specified here,
-    /// or until [`Self::clear`] is called.
+    /// The event will be queued until [`RepliconTick`] will be bigger or equal to the tick specified here.
     pub fn insert(&mut self, tick: RepliconTick, event: T) {
         self.0.insert(tick, event);
-    }
-
-    /// Pops the next event that is at least as old as the specified replicon tick.
-    pub fn pop_next(&mut self, replicon_tick: RepliconTick) -> Option<T> {
-        let (tick, _) = self.0.front()?;
-        if *tick > replicon_tick {
-            return None;
-        }
-        self.0.pop_front().map(|(_, event)| event)
     }
 }
 


### PR DESCRIPTION
In discord we discussed customization without the full access to `ServerEventQueue`.