### PR TITLE
Implement shared bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Speedup serialization for multiple clients by reusing already serialized components and entities.
 - Hide extra functionality from `ServerEventQueue`.
-- Moved server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.
+- Move server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.
 - Make `NetworkChannels` channel-creation methods public (`create_client_channel()` and `create_server_channel()`).
 - Implement `Eq` and `PartialEq` on `EventType`.
 

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -635,7 +635,7 @@ impl Default for UpdateMessage {
     }
 }
 
-/// Writes a new data into cursor returns serialized size.
+/// Writes new data into a cursor and returns the serialized size.
 ///
 /// Reuses previously shared bytes if they exist, or updates them.
 /// Serialized size should be less then [`u16`].

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -212,8 +212,15 @@ impl InitMessage {
     ///
     /// Should be called only inside an array and increases its length by 1.
     /// See also [`Self::start_array`].
-    pub(super) fn write_entity(&mut self, entity: Entity) -> bincode::Result<()> {
-        serialize_entity(&mut self.cursor, entity)?;
+    pub(super) fn write_entity<'a>(
+        &'a mut self,
+        shared_bytes: &mut Option<&'a [u8]>,
+        entity: Entity,
+    ) -> bincode::Result<()> {
+        write_with(shared_bytes, &mut self.cursor, |cursor| {
+            serialize_entity(cursor, entity)
+        })?;
+
         self.array_len = self
             .array_len
             .checked_add(1)
@@ -283,8 +290,9 @@ impl InitMessage {
     ///
     /// Should be called only inside an entity data and increases its size.
     /// See also [`Self::start_entity_data`].
-    pub(super) fn write_component(
-        &mut self,
+    pub(super) fn write_component<'a>(
+        &'a mut self,
+        shared_bytes: &mut Option<&'a [u8]>,
         replication_info: &ReplicationInfo,
         replication_id: ReplicationId,
         ptr: Ptr,
@@ -293,11 +301,14 @@ impl InitMessage {
             self.write_data_entity()?;
         }
 
-        let component_size =
-            serialize_component(&mut self.cursor, replication_id, replication_info, ptr)?;
+        let size = write_with(shared_bytes, &mut self.cursor, |cursor| {
+            DefaultOptions::new().serialize_into(&mut *cursor, &replication_id)?;
+            (replication_info.serialize)(ptr, cursor)
+        })?;
+
         self.entity_data_size = self
             .entity_data_size
-            .checked_add(component_size)
+            .checked_add(size)
             .ok_or(bincode::ErrorKind::SizeLimit)?;
 
         Ok(())
@@ -504,8 +515,9 @@ impl UpdateMessage {
     ///
     /// Should be called only inside an entity data and increases its size.
     /// See also [`Self::start_entity_data`].
-    pub(super) fn write_component(
-        &mut self,
+    pub(super) fn write_component<'a>(
+        &'a mut self,
+        shared_bytes: &mut Option<&'a [u8]>,
         replication_info: &ReplicationInfo,
         replication_id: ReplicationId,
         ptr: Ptr,
@@ -514,11 +526,14 @@ impl UpdateMessage {
             self.write_data_entity()?;
         }
 
-        let component_size =
-            serialize_component(&mut self.cursor, replication_id, replication_info, ptr)?;
+        let size = write_with(shared_bytes, &mut self.cursor, |cursor| {
+            DefaultOptions::new().serialize_into(&mut *cursor, &replication_id)?;
+            (replication_info.serialize)(ptr, cursor)
+        })?;
+
         self.entity_data_size = self
             .entity_data_size
-            .checked_add(component_size)
+            .checked_add(size)
             .ok_or(bincode::ErrorKind::SizeLimit)?;
 
         Ok(())
@@ -617,21 +632,32 @@ impl Default for UpdateMessage {
     }
 }
 
-/// Serializes component with replication ID and returns serialized size.
-fn serialize_component(
-    cursor: &mut Cursor<Vec<u8>>,
-    replication_id: ReplicationId,
-    replication_info: &ReplicationInfo,
-    ptr: Ptr<'_>,
+fn write_with<'a>(
+    shared_bytes: &mut Option<&'a [u8]>,
+    cursor: &'a mut Cursor<Vec<u8>>,
+    write_fn: impl FnOnce(&mut Cursor<Vec<u8>>) -> bincode::Result<()>,
 ) -> bincode::Result<u16> {
-    let previous_pos = cursor.position();
-    DefaultOptions::new().serialize_into(&mut *cursor, &replication_id)?;
-    (replication_info.serialize)(ptr, cursor)?;
-    let component_size = (cursor.position() - previous_pos)
+    let bytes = if let Some(bytes) = shared_bytes {
+        cursor.write_all(bytes)?;
+        bytes
+    } else {
+        let previous_pos = cursor.position() as usize;
+        (write_fn(cursor))?;
+        let current_pos = cursor.position() as usize;
+
+        let buffer = cursor.get_ref();
+        let bytes = &buffer[previous_pos..current_pos];
+        *shared_bytes = Some(bytes);
+
+        bytes
+    };
+
+    let size = bytes
+        .len()
         .try_into()
         .map_err(|_| bincode::ErrorKind::SizeLimit)?;
 
-    Ok(component_size)
+    Ok(size)
 }
 
 fn can_pack(header_size: usize, base: usize, add: usize) -> bool {

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -210,6 +210,7 @@ impl InitMessage {
 
     /// Serializes entity as an array element.
     ///
+    /// Reuses previously shared bytes if they exist, or updates them.
     /// Should be called only inside an array and increases its length by 1.
     /// See also [`Self::start_array`].
     pub(super) fn write_entity<'a>(
@@ -288,6 +289,7 @@ impl InitMessage {
 
     /// Serializes component and its replication ID as an element of entity data.
     ///
+    /// Reuses previously shared bytes if they exist, or updates them.
     /// Should be called only inside an entity data and increases its size.
     /// See also [`Self::start_entity_data`].
     pub(super) fn write_component<'a>(
@@ -513,6 +515,7 @@ impl UpdateMessage {
 
     /// Serializes component and its replication ID as an element of entity data.
     ///
+    /// Reuses previously shared bytes if they exist, or updates them.
     /// Should be called only inside an entity data and increases its size.
     /// See also [`Self::start_entity_data`].
     pub(super) fn write_component<'a>(
@@ -632,6 +635,10 @@ impl Default for UpdateMessage {
     }
 }
 
+/// Writes a new data into cursor returns serialized size.
+///
+/// Reuses previously shared bytes if they exist, or updates them.
+/// Serialized size should be less then [`u16`].
 fn write_with<'a>(
     shared_bytes: &mut Option<&'a [u8]>,
     cursor: &'a mut Cursor<Vec<u8>>,


### PR DESCRIPTION
Inspired by #169, but:
- Uses slices instead of intermediate buffer.
- Does not reuses entity serialization inside entity data due to borrowing issues.

Comparison with #169:
```
UsizeComponent, init send, 1 client(s)
                        time:   [67.247 µs 67.696 µs 68.508 µs]
                        change: [-10.450% -8.9941% -7.6232%] (p = 0.00 < 0.05)
                        Performance has improved.

UsizeComponent, update send, 1 client(s)
                        time:   [75.610 µs 77.360 µs 78.692 µs]
                        change: [-11.494% -9.3210% -7.0994%] (p = 0.00 < 0.05)
                        Performance has improved.

UsizeComponent, init send, 20 client(s)
                        time:   [1.0410 ms 1.0429 ms 1.0446 ms]
                        change: [-6.4814% -6.1384% -5.8549%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild

UsizeComponent, update send, 20 client(s)
                        time:   [1.0534 ms 1.0563 ms 1.0595 ms]
                        change: [-7.8087% -6.7710% -5.5481%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  2 (10.00%) high severe

StringComponent, init send, 1 client(s)
                        time:   [215.77 µs 216.27 µs 216.92 µs]
                        change: [-10.037% -9.7897% -9.5416%] (p = 0.00 < 0.05)
                        Performance has improved.

StringComponent, update send, 1 client(s)
                        time:   [237.25 µs 238.00 µs 238.83 µs]
                        change: [-7.4296% -7.0007% -6.6066%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  2 (10.00%) high mild

StringComponent, init send, 20 client(s)
                        time:   [3.9775 ms 3.9879 ms 3.9962 ms]
                        change: [-10.713% -10.483% -10.259%] (p = 0.00 < 0.05)
                        Performance has improved.

StringComponent, update send, 20 client(s)
                        time:   [4.3319 ms 4.3396 ms 4.3500 ms]
                        change: [-4.0496% -2.6552% -1.1521%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high severe

StructComponent, init send, 1 client(s)
                        time:   [132.26 µs 132.62 µs 132.96 µs]
                        change: [-13.055% -12.672% -12.313%] (p = 0.00 < 0.05)
                        Performance has improved.

StructComponent, update send, 1 client(s)
                        time:   [143.45 µs 144.14 µs 144.83 µs]
                        change: [-9.9160% -9.3432% -8.7567%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

StructComponent, init send, 20 client(s)
                        time:   [2.2020 ms 2.2149 ms 2.2280 ms]
                        change: [-3.5260% -2.5105% -1.4157%] (p = 0.00 < 0.05)
                        Performance has improved.

StructComponent, update send, 20 client(s)
                        time:   [2.3449 ms 2.3529 ms 2.3649 ms]
                        change: [-2.7899% -1.7220% -0.7619%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 20 measurements (15.00%)
  1 (5.00%) high mild
  2 (10.00%) high severe
```