### PR TITLE
Track change tick for each client individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- API for custom server messages now use `server_event::serialize_with`  and `server_event::deserialize_with`, for more details see the example in the docs.
 - Speedup serialization for multiple clients by reusing already serialized components and entities.
 - Hide extra functionality from `ServerEventQueue`.
 - Move server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.
 - Make `NetworkChannels` channel-creation methods public (`create_client_channel()` and `create_server_channel()`).
 - Implement `Eq` and `PartialEq` on `EventType`.
+
+### Removed
+
+- `LastChangeTick` resource, `ClientsInfo` should be used instead.
+- `SendMode::BroadcastExcept`, use multiple `SendMode::Direct`.
 
 ## [0.19.0] - 2024-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- API for custom server messages now use `server_event::serialize_with`  and `server_event::deserialize_with`, for more details see the example in the docs.
+- API for custom server messages now uses `server_event::serialize_with`  and `server_event::deserialize_with`. For more details see the example in the docs.
 - Speedup serialization for multiple clients by reusing already serialized components and entities.
 - Hide extra functionality from `ServerEventQueue`.
 - Move server event reset system to new set `ClientSet::ResetEvents` in `PreUpdate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `LastChangeTick` resource, `ClientsInfo` should be used instead.
-- `SendMode::BroadcastExcept`, use multiple `SendMode::Direct`.
 
 ## [0.19.0] - 2024-01-07
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,7 +161,7 @@ fn apply_replication(
 
     let mut result = Ok(());
     buffered_updates.0.retain(|update| {
-        if update.last_change_tick > replicon_tick {
+        if update.change_tick > replicon_tick {
             return true;
         }
 
@@ -276,11 +276,11 @@ fn apply_update_message(
         stats.bytes += end_pos;
     }
 
-    let (last_change_tick, message_tick, update_index) = bincode::deserialize_from(&mut cursor)?;
-    if last_change_tick > replicon_tick {
+    let (change_tick, message_tick, update_index) = bincode::deserialize_from(&mut cursor)?;
+    if change_tick > replicon_tick {
         trace!("buffering update message for {message_tick:?}");
         buffered_updates.0.push(BufferedUpdate {
-            last_change_tick,
+            change_tick,
             message_tick,
             message: message.slice(cursor.position() as usize..),
         });
@@ -534,9 +534,7 @@ impl BufferedUpdates {
 /// See also [`crate::server::replication_messages::UpdateMessage`].
 pub(super) struct BufferedUpdate {
     /// Required tick to wait for.
-    ///
-    /// See also [`crate::server::LastChangeTick`].
-    last_change_tick: RepliconTick,
+    change_tick: RepliconTick,
 
     /// The tick this update corresponds to.
     message_tick: RepliconTick,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,8 +432,8 @@ pub mod prelude {
             NetworkChannels, ReplicationChannel, RepliconCorePlugin,
         },
         server::{
-            has_authority, ClientEntityMap, ClientMapping, LastChangeTick, ServerPlugin, ServerSet,
-            TickPolicy, SERVER_ID,
+            clients_info::ClientsInfo, has_authority, ClientEntityMap, ClientMapping, ServerPlugin,
+            ServerSet, TickPolicy, SERVER_ID,
         },
         ReplicationPlugins,
     };

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -362,6 +362,7 @@ fn serialize_with(
     }
 }
 
+/// Deserializes event change tick first and then calls the specified deserialization function to get the event itself.
 pub fn deserialize_with<T>(
     message: &[u8],
     deserialize_fn: impl FnOnce(&mut Cursor<&[u8]>) -> bincode::Result<T>,

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -301,7 +301,7 @@ pub fn send_with<T>(
         SendMode::Broadcast => {
             let mut shared_bytes = None;
             for client_info in clients_info.iter() {
-                let message = serialize_with(&client_info, shared_bytes, &serialize_fn)?;
+                let message = serialize_with(client_info, shared_bytes, &serialize_fn)?;
                 shared_bytes = Some(message.clone());
                 server.send_message(client_info.id(), channel, message);
             }
@@ -312,7 +312,7 @@ pub fn send_with<T>(
                     .iter()
                     .find(|client_info| client_info.id() == client_id)
                 {
-                    let message = serialize_with(&client_info, None, &serialize_fn)?;
+                    let message = serialize_with(client_info, None, &serialize_fn)?;
                     server.send_message(client_info.id(), channel, message);
                 }
             }

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -286,10 +286,9 @@ fn reset_system<T: Event>(mut event_queue: ResMut<ServerEventQueue<T>>) {
     event_queue.0.clear();
 }
 
-/// Sends serialized `message` to clients.
-///
 /// Helper for custom sending systems.
-/// See also [`ServerEventAppExt::add_server_event_with`]
+///
+/// See also [`ServerEventAppExt::add_server_event_with`].
 pub fn send_with<T>(
     server: &mut RenetServer,
     clients_info: &ClientsInfo,

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -1,7 +1,9 @@
+use std::io::Cursor;
+
 use bevy::{ecs::event::Event, prelude::*};
 use bevy_renet::{
     client_connected,
-    renet::{ClientId, RenetClient, RenetServer, SendType},
+    renet::{Bytes, ClientId, RenetClient, RenetServer, SendType},
 };
 use bincode::{DefaultOptions, Options};
 use ordered_multimap::ListOrderedMultimap;
@@ -15,7 +17,10 @@ use crate::{
     replicon_core::{
         replication_rules::MapNetworkEntities, replicon_tick::RepliconTick, NetworkChannels,
     },
-    server::{has_authority, LastChangeTick, ServerSet, SERVER_ID},
+    server::{
+        clients_info::{ClientInfo, ClientsInfo},
+        has_authority, ServerSet, SERVER_ID,
+    },
 };
 
 /// An extension trait for [`App`] for creating server events.
@@ -66,16 +71,17 @@ pub trait ServerEventAppExt {
     fn sending_reflect_system(
         mut server: ResMut<RenetServer>,
         mut reflect_events: EventReader<ToClients<ReflectEvent>>,
-        last_change_tick: Res<LastChangeTick>,
+        clients_info: Res<ClientsInfo>,
         channel: Res<ServerEventChannel<ReflectEvent>>,
         registry: Res<AppTypeRegistry>,
     ) {
         let registry = registry.read();
         for ToClients { event, mode } in reflect_events.read() {
-            let message = serialize_reflect_event(**last_change_tick, &event, &registry)
-                .expect("server event should be serializable");
-
-            server_event::send(&mut server, *channel, *mode, message)
+            server_event::send_with(&mut server, &clients_info, *channel, *mode, |cursor| {
+                let serializer = ReflectSerializer::new(&*event.0, &registry);
+                DefaultOptions::new().serialize_into(cursor, &serializer)
+            })
+            .expect("server event should be serializable");
         }
     }
 
@@ -89,8 +95,13 @@ pub trait ServerEventAppExt {
     ) {
         let registry = registry.read();
         while let Some(message) = client.receive_message(*channel) {
-            let (tick, event) = deserialize_reflect_event(&message, &registry)
-                .expect("server should send valid events");
+            let (tick, event) = server_event::deserialize_with(&message, |cursor| {
+                let mut deserializer =
+                    bincode::Deserializer::with_reader(cursor, DefaultOptions::new());
+                let reflect = UntypedReflectDeserializer::new(&registry).deserialize(&mut deserializer)?;
+                Ok(ReflectEvent(reflect))
+            })
+            .expect("server should send valid events");
 
             // Event should be sent to the queue if replication message with its tick has not yet arrived.
             if tick <= *replicon_tick {
@@ -103,32 +114,6 @@ pub trait ServerEventAppExt {
 
     #[derive(Event)]
     struct ReflectEvent(Box<dyn Reflect>);
-
-    fn serialize_reflect_event(
-        tick: RepliconTick,
-        event: &ReflectEvent,
-        registry: &TypeRegistry,
-    ) -> bincode::Result<Vec<u8>> {
-        let mut message = Vec::new();
-        DefaultOptions::new().serialize_into(&mut message, &tick)?;
-        let serializer = ReflectSerializer::new(&*event.0, registry);
-        DefaultOptions::new().serialize_into(&mut message, &serializer)?;
-
-        Ok(message)
-    }
-
-    fn deserialize_reflect_event(
-        message: &[u8],
-        registry: &TypeRegistry,
-    ) -> bincode::Result<(RepliconTick, ReflectEvent)> {
-        let mut cursor = Cursor::new(message);
-        let tick = DefaultOptions::new().deserialize_from(&mut cursor)?;
-        let mut deserializer =
-            bincode::Deserializer::with_reader(&mut cursor, DefaultOptions::new());
-        let reflect = UntypedReflectDeserializer::new(registry).deserialize(&mut deserializer)?;
-
-        Ok((tick, ReflectEvent(reflect)))
-    }
     ```
     */
     fn add_server_event_with<T: Event, Marker1, Marker2>(
@@ -218,9 +203,10 @@ fn receiving_system<T: Event + DeserializeOwned>(
     channel: Res<ServerEventChannel<T>>,
 ) {
     while let Some(message) = client.receive_message(*channel) {
-        let (tick, event) = DefaultOptions::new()
-            .deserialize(&message)
-            .expect("server should send valid events");
+        let (tick, event) = deserialize_with(&message, |cursor| {
+            DefaultOptions::new().deserialize_from(cursor)
+        })
+        .expect("server should send valid events");
 
         if tick <= *replicon_tick {
             server_events.send(event);
@@ -239,9 +225,10 @@ fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned
     channel: Res<ServerEventChannel<T>>,
 ) {
     while let Some(message) = client.receive_message(*channel) {
-        let (tick, mut event): (_, T) = DefaultOptions::new()
-            .deserialize(&message)
-            .expect("server should send valid mapped events");
+        let (tick, mut event): (_, T) = deserialize_with(&message, |cursor| {
+            DefaultOptions::new().deserialize_from(cursor)
+        })
+        .expect("server should send valid events");
 
         event.map_entities(&mut EventMapper(entity_map.to_client()));
         if tick <= *replicon_tick {
@@ -255,15 +242,14 @@ fn receiving_and_mapping_system<T: Event + MapNetworkEntities + DeserializeOwned
 fn sending_system<T: Event + Serialize>(
     mut server: ResMut<RenetServer>,
     mut server_events: EventReader<ToClients<T>>,
-    last_change_tick: Res<LastChangeTick>,
+    clients_info: Res<ClientsInfo>,
     channel: Res<ServerEventChannel<T>>,
 ) {
     for ToClients { event, mode } in server_events.read() {
-        let message = DefaultOptions::new()
-            .serialize(&(**last_change_tick, event))
-            .expect("server event should be serializable");
-
-        send(&mut server, *channel, *mode, message);
+        send_with(&mut server, &clients_info, *channel, *mode, |cursor| {
+            DefaultOptions::new().serialize_into(cursor, &event)
+        })
+        .expect("server event should be serializable");
     }
 }
 
@@ -277,11 +263,6 @@ fn local_resending_system<T: Event>(
         match mode {
             SendMode::Broadcast => {
                 local_events.send(event);
-            }
-            SendMode::BroadcastExcept(client_id) => {
-                if client_id != SERVER_ID {
-                    local_events.send(event);
-                }
             }
             SendMode::Direct(client_id) => {
                 if client_id == SERVER_ID {
@@ -309,29 +290,64 @@ fn reset_system<T: Event>(mut event_queue: ResMut<ServerEventQueue<T>>) {
 ///
 /// Helper for custom sending systems.
 /// See also [`ServerEventAppExt::add_server_event_with`]
-pub fn send<T>(
+pub fn send_with<T>(
     server: &mut RenetServer,
+    clients_info: &ClientsInfo,
     channel: ServerEventChannel<T>,
     mode: SendMode,
-    message: Vec<u8>,
-) {
+    serialize_fn: impl Fn(&mut Cursor<Vec<u8>>) -> bincode::Result<()>,
+) -> bincode::Result<()> {
     match mode {
         SendMode::Broadcast => {
-            server.broadcast_message(channel, message);
-        }
-        SendMode::BroadcastExcept(client_id) => {
-            if client_id == SERVER_ID {
-                server.broadcast_message(channel, message);
-            } else {
-                server.broadcast_message_except(client_id, channel, message);
+            let mut shared_bytes = None;
+            for client_info in clients_info.iter() {
+                let message = serialize_with(&client_info, shared_bytes, &serialize_fn)?;
+                shared_bytes = Some(message.clone());
+                server.send_message(client_info.id(), channel, message);
             }
         }
         SendMode::Direct(client_id) => {
             if client_id != SERVER_ID {
-                server.send_message(client_id, channel, message);
+                if let Some(client_info) = clients_info
+                    .iter()
+                    .find(|client_info| client_info.id() == client_id)
+                {
+                    let message = serialize_with(&client_info, None, &serialize_fn)?;
+                    server.send_message(client_info.id(), channel, message);
+                }
             }
         }
     }
+
+    Ok(())
+}
+
+fn serialize_with(
+    client_info: &ClientInfo,
+    shared_bytes: Option<Bytes>,
+    serialize_fn: impl Fn(&mut Cursor<Vec<u8>>) -> bincode::Result<()>,
+) -> bincode::Result<Bytes> {
+    if let Some(shared_bytes) = &shared_bytes {
+        let mut message = Vec::from(&shared_bytes[..]);
+        DefaultOptions::new().serialize_into(&mut message[..], &client_info.change_tick)?;
+        Ok(message.into())
+    } else {
+        let mut cursor = Default::default();
+        DefaultOptions::new().serialize_into(&mut cursor, &client_info.change_tick)?;
+        (serialize_fn)(&mut cursor)?;
+        Ok(cursor.into_inner().into())
+    }
+}
+
+pub fn deserialize_with<T>(
+    message: &[u8],
+    deserialize_fn: impl FnOnce(&mut Cursor<&[u8]>) -> bincode::Result<T>,
+) -> bincode::Result<(RepliconTick, T)> {
+    let mut cursor = Cursor::new(message);
+    let tick = DefaultOptions::new().deserialize_from(&mut cursor)?;
+    let event = (deserialize_fn)(&mut cursor)?;
+
+    Ok((tick, event))
 }
 
 /// An event that will be send to client(s).
@@ -345,7 +361,6 @@ pub struct ToClients<T> {
 #[derive(Clone, Copy, Debug)]
 pub enum SendMode {
     Broadcast,
-    BroadcastExcept(ClientId),
     Direct(ClientId),
 }
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -347,9 +347,9 @@ fn serialize_with(
             return Ok(previous_message);
         }
 
-        let mut bytes = Vec::with_capacity(previous_message.bytes.len());
+        let tick_size = DefaultOptions::new().serialized_size(&client_info.change_tick)? as usize;
+        let mut bytes = Vec::with_capacity(tick_size + previous_message.event_bytes().len());
         DefaultOptions::new().serialize_into(&mut bytes, &client_info.change_tick)?;
-        let tick_size = bytes.len();
         bytes.extend_from_slice(previous_message.event_bytes());
         let message = SerializedMessage {
             tick: client_info.change_tick,

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -349,10 +349,11 @@ fn serialize_with(
 
         let mut bytes = Vec::with_capacity(previous_message.bytes.len());
         DefaultOptions::new().serialize_into(&mut bytes, &client_info.change_tick)?;
+        let tick_size = bytes.len();
         bytes.extend_from_slice(previous_message.event_bytes());
         let message = SerializedMessage {
             tick: client_info.change_tick,
-            tick_size: previous_message.tick_size,
+            tick_size,
             bytes: bytes.into(),
         };
 

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -358,9 +358,9 @@ fn serialize_with(
 
         Ok(message)
     } else {
-        let tick_size = DefaultOptions::new().serialized_size(&client_info.change_tick)? as usize;
         let mut cursor = Cursor::new(Vec::new());
         DefaultOptions::new().serialize_into(&mut cursor, &client_info.change_tick)?;
+        let tick_size = cursor.get_ref().len();
         (serialize_fn)(&mut cursor)?;
         let message = SerializedMessage {
             tick: client_info.change_tick,

--- a/src/server.rs
+++ b/src/server.rs
@@ -64,7 +64,6 @@ impl Plugin for ServerPlugin {
         ))
         .init_resource::<ClientsInfo>()
         .init_resource::<ClientBuffers>()
-        .init_resource::<LastChangeTick>()
         .init_resource::<ClientEntityMap>()
         .configure_sets(PreUpdate, ServerSet::Receive.after(RenetReceive))
         .configure_sets(PostUpdate, ServerSet::Send.before(RenetSend))
@@ -194,7 +193,6 @@ impl ServerPlugin {
             ResMut<ClientEntityMap>,
             ResMut<DespawnBuffer>,
             ResMut<RemovalBuffer>,
-            ResMut<LastChangeTick>,
             ResMut<ClientBuffers>,
             ResMut<RenetServer>,
         )>,
@@ -218,12 +216,10 @@ impl ServerPlugin {
         collect_despawns(&mut messages, &mut set.p3())?;
         collect_removals(&mut messages, &mut set.p4(), change_tick.this_run())?;
 
-        let last_change_tick = *set.p5();
-        let mut client_buffers = mem::take(&mut *set.p6());
-        let (last_change_tick, clients_info) = messages.send(
-            &mut set.p7(),
+        let mut client_buffers = mem::take(&mut *set.p5());
+        let clients_info = messages.send(
+            &mut set.p6(),
             &mut client_buffers,
-            last_change_tick,
             *replicon_tick,
             change_tick.this_run(),
             time.elapsed(),
@@ -231,8 +227,7 @@ impl ServerPlugin {
 
         // Return borrowed data back.
         *set.p1() = clients_info;
-        *set.p5() = last_change_tick;
-        *set.p6() = client_buffers;
+        *set.p5() = client_buffers;
 
         Ok(())
     }
@@ -503,13 +498,6 @@ pub enum TickPolicy {
     /// [`RepliconTick`].
     Manual,
 }
-
-/// Contains the last tick in which a replicated entity was spawned, despawned, or gained/lost a component.
-///
-/// It should be included in update messages and server events instead of the current tick
-/// to avoid needless waiting for the next init message to arrive.
-#[derive(Clone, Copy, Debug, Default, Deref, Resource)]
-pub struct LastChangeTick(RepliconTick);
 
 /**
 A resource that exists on the server for mapping server entities to

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -86,7 +86,7 @@ pub(crate) struct ClientInfo {
     /// Client's ID.
     id: ClientId,
 
-    /// Indicates whether the client is connected at this tick.
+    /// Indicates whether the client connected in this tick.
     pub(super) just_connected: bool,
 
     /// Last acknowledged tick for each entity.
@@ -97,10 +97,10 @@ pub(crate) struct ClientInfo {
     /// It should be included in update messages and server events to avoid needless waiting for the next init message to arrive.
     pub(crate) change_tick: RepliconTick,
 
-    /// Update message indexes mapped the their info.
+    /// Update message indexes mapped to their info.
     updates: HashMap<u16, UpdateInfo>,
 
-    /// Next index for update message.
+    /// Index for the next update message to be sent to this client.
     ///
     /// See also [`Self::register_update`].
     next_update_index: u16,

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -71,7 +71,7 @@ impl ReplicationMessages {
 
     /// Sends cached messages to clients specified in the last [`Self::prepare`] call.
     ///
-    /// Updates change tick for each client, which will equal the latest replicon tick if any init
+    /// The change tick of each client with an init message is updated to equal the latest replicon tick.
     /// messages were sent to clients. If only update messages were sent (or no messages at all) then
     /// it will equal the input `last_change_tick`.
     pub(super) fn send(

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -5,13 +5,13 @@ use std::{
 };
 
 use bevy::{ecs::component::Tick, prelude::*, ptr::Ptr};
-use bevy_renet::renet::{Bytes, ClientId, RenetServer};
+use bevy_renet::renet::{Bytes, RenetServer};
 use bincode::{DefaultOptions, Options};
 use varint_rs::VarintWriter;
 
 use super::{
     clients_info::{ClientBuffers, ClientsInfo},
-    ClientInfo, ClientMapping, LastChangeTick,
+    ClientInfo, ClientMapping,
 };
 use crate::replicon_core::{
     replication_rules::{ReplicationId, ReplicationInfo},
@@ -71,33 +71,25 @@ impl ReplicationMessages {
 
     /// Sends cached messages to clients specified in the last [`Self::prepare`] call.
     ///
-    /// Returns the server's last change tick, which will equal the latest replicon tick if any init
+    /// Updates change tick for each client, which will equal the latest replicon tick if any init
     /// messages were sent to clients. If only update messages were sent (or no messages at all) then
     /// it will equal the input `last_change_tick`.
     pub(super) fn send(
         &mut self,
         server: &mut RenetServer,
         client_buffers: &mut ClientBuffers,
-        mut last_change_tick: LastChangeTick,
         replicon_tick: RepliconTick,
         tick: Tick,
         timestamp: Duration,
-    ) -> bincode::Result<(LastChangeTick, ClientsInfo)> {
-        if let Some((init_message, _)) = self.data.first() {
-            if !init_message.as_slice().is_empty() {
-                last_change_tick.0 = replicon_tick;
-            }
-        }
-
+    ) -> bincode::Result<ClientsInfo> {
         for ((init_message, update_message), client_info) in
             self.data.iter_mut().zip(self.clients_info.iter_mut())
         {
-            init_message.send(server, replicon_tick, client_info.id())?;
+            init_message.send(server, client_info, replicon_tick)?;
             update_message.send(
                 server,
                 client_buffers,
                 client_info,
-                last_change_tick,
                 replicon_tick,
                 tick,
                 timestamp,
@@ -106,7 +98,7 @@ impl ReplicationMessages {
 
         let clients_info = mem::take(&mut self.clients_info);
 
-        Ok((last_change_tick, clients_info))
+        Ok(clients_info)
     }
 }
 
@@ -378,28 +370,31 @@ impl InitMessage {
 
     /// Sends the message, excluding trailing empty arrays, to the specified client.
     ///
+    /// Updates change tick for the client if there are data to send.
     /// Does nothing if there is no data to send.
     fn send(
         &self,
         server: &mut RenetServer,
+        client_info: &mut ClientInfo,
         replicon_tick: RepliconTick,
-        client_id: ClientId,
     ) -> bincode::Result<()> {
         debug_assert_eq!(self.array_len, 0);
         debug_assert_eq!(self.entity_data_size, 0);
 
         let slice = self.as_slice();
         if slice.is_empty() {
-            trace!("no init data to send for client {client_id}");
+            trace!("no init data to send for client {}", client_info.id());
             return Ok(());
         }
+
+        client_info.change_tick = replicon_tick;
 
         let mut header = [0; mem::size_of::<RepliconTick>()];
         bincode::serialize_into(&mut header[..], &replicon_tick)?;
 
-        trace!("sending init message to client {client_id}");
+        trace!("sending init message to client {}", client_info.id());
         server.send_message(
-            client_id,
+            client_info.id(),
             ReplicationChannel::Reliable,
             Bytes::from([&header, slice].concat()),
         );
@@ -425,8 +420,8 @@ impl Default for InitMessage {
 
 /// A reusable message with replicated component updates.
 ///
-/// Contains last change tick, current tick and component updates since the last acknowledged tick for each entity.
-/// Cannot be applied on the client until the init message matching this update message's last change tick
+/// Contains change tick, current tick and component updates since the last acknowledged tick for each entity.
+/// Cannot be applied on the client until the init message matching this update message's change tick
 /// has been applied to the client world.
 /// The message will be manually split into packets up to max size, and each packet will be applied
 /// independently on the client.
@@ -552,13 +547,11 @@ impl UpdateMessage {
     /// Splits message according to entities inside it and sends it to the specified client.
     ///
     /// Does nothing if there is no data to send.
-    #[allow(clippy::too_many_arguments)]
     fn send(
         &mut self,
         server: &mut RenetServer,
         client_buffers: &mut ClientBuffers,
         client_info: &mut ClientInfo,
-        last_change_tick: LastChangeTick,
         replicon_tick: RepliconTick,
         tick: Tick,
         timestamp: Duration,
@@ -574,7 +567,7 @@ impl UpdateMessage {
         trace!("sending update message(s) to client {}", client_info.id());
         const TICKS_SIZE: usize = 2 * mem::size_of::<RepliconTick>();
         let mut header = [0; TICKS_SIZE + mem::size_of::<u16>()];
-        bincode::serialize_into(&mut header[..], &(*last_change_tick, replicon_tick))?;
+        bincode::serialize_into(&mut header[..], &(client_info.change_tick, replicon_tick))?;
 
         let mut message_size = 0;
         let client_id = client_info.id();

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -52,6 +52,8 @@ fn sending_receiving() {
         (SendMode::Broadcast, 1),
         (SendMode::Direct(SERVER_ID), 0),
         (SendMode::Direct(client_id), 1),
+        (SendMode::BroadcastExcept(SERVER_ID), 1),
+        (SendMode::BroadcastExcept(client_id), 0),
     ] {
         server_app
             .world
@@ -134,6 +136,8 @@ fn local_resending() {
         (SendMode::Broadcast, 1),
         (SendMode::Direct(SERVER_ID), 1),
         (SendMode::Direct(DUMMY_CLIENT_ID), 0),
+        (SendMode::BroadcastExcept(SERVER_ID), 0),
+        (SendMode::BroadcastExcept(DUMMY_CLIENT_ID), 1),
     ] {
         app.world
             .resource_mut::<Events<ToClients<DummyEvent>>>()

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -52,8 +52,6 @@ fn sending_receiving() {
         (SendMode::Broadcast, 1),
         (SendMode::Direct(SERVER_ID), 0),
         (SendMode::Direct(client_id), 1),
-        (SendMode::BroadcastExcept(SERVER_ID), 1),
-        (SendMode::BroadcastExcept(client_id), 0),
     ] {
         server_app
             .world
@@ -136,8 +134,6 @@ fn local_resending() {
         (SendMode::Broadcast, 1),
         (SendMode::Direct(SERVER_ID), 1),
         (SendMode::Direct(DUMMY_CLIENT_ID), 0),
-        (SendMode::BroadcastExcept(SERVER_ID), 0),
-        (SendMode::BroadcastExcept(DUMMY_CLIENT_ID), 1),
     ] {
         app.world
             .resource_mut::<Events<ToClients<DummyEvent>>>()


### PR DESCRIPTION
It's a more correct approach and will be needed for the upcoming rooms.

I had to remove `SendType::BroadcastExcept` because it's no longer make sense since the messages now individual.