### PR TITLE
Test change tick for clients connecting at different times.

### DIFF
--- a/tests/connect/mod.rs
+++ b/tests/connect/mod.rs
@@ -30,7 +30,7 @@ pub(super) fn multiple_clients(server_app: &mut App, client_apps: &mut [App]) {
     }
 }
 
-fn setup_client(app: &mut App, client_id: u64, port: u16) {
+pub(super) fn setup_client(app: &mut App, client_id: u64, port: u16) {
     let network_channels = app.world.resource::<NetworkChannels>();
 
     let server_channels_config = network_channels.get_server_configs();
@@ -46,7 +46,7 @@ fn setup_client(app: &mut App, client_id: u64, port: u16) {
     app.insert_resource(client).insert_resource(transport);
 }
 
-fn setup_server(app: &mut App, max_clients: usize) -> u16 {
+pub(super) fn setup_server(app: &mut App, max_clients: usize) -> u16 {
     let network_channels = app.world.resource::<NetworkChannels>();
 
     let server_channels_config = network_channels.get_server_configs();
@@ -65,7 +65,7 @@ fn setup_server(app: &mut App, max_clients: usize) -> u16 {
     port
 }
 
-fn wait_for_connection(server_app: &mut App, client_app: &mut App) {
+pub(super) fn wait_for_connection(server_app: &mut App, client_app: &mut App) {
     loop {
         client_app.update();
         server_app.update();

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -210,7 +210,7 @@ fn client_mismatch() {
     let mut server_app = App::new();
     let mut client_app1 = App::new();
     let mut client_app2 = App::new();
-    for app in [&mut server_app, &mut client_app1,  &mut client_app2] {
+    for app in [&mut server_app, &mut client_app1, &mut client_app2] {
         app.add_plugins((
             MinimalPlugins,
             ReplicationPlugins.set(ServerPlugin {

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -201,8 +201,7 @@ fn event_queue() {
 
     client_app.update();
 
-    let dummy_events = client_app.world.resource::<Events<DummyEvent>>();
-    assert_eq!(dummy_events.len(), 1);
+    assert_eq!(client_app.world.resource::<Events<DummyEvent>>().len(), 1);
 }
 
 #[test]

--- a/tests/server_event.rs
+++ b/tests/server_event.rs
@@ -205,6 +205,58 @@ fn event_queue() {
     assert_eq!(dummy_events.len(), 1);
 }
 
+#[test]
+fn client_mismatch() {
+    let mut server_app = App::new();
+    let mut client_app1 = App::new();
+    let mut client_app2 = App::new();
+    for app in [&mut server_app, &mut client_app1,  &mut client_app2] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<DummyComponent>()
+        .add_server_event::<DummyEvent>(EventType::Ordered);
+    }
+
+    // 1. Connect client 1.
+    let port = connect::setup_server(&mut server_app, 2);
+    connect::setup_client(&mut client_app1, 1u64, port);
+    connect::wait_for_connection(&mut server_app, &mut client_app1);
+
+    // 2. Spawn entity to trigger world change.
+    server_app.world.spawn((Replication, DummyComponent));
+
+    // 3. Update client 1 to initialize their replicon tick.
+    server_app.update();
+    client_app1.update();
+
+    // 3. Connect client 2.
+    // - Client 2 will have a higher replicon tick than client 1, since only client 1 will recieve an init message
+    //   here.
+    connect::setup_client(&mut client_app2, 2u64, port);
+    connect::wait_for_connection(&mut server_app, &mut client_app2);
+
+    // 4. Send event to all clients.
+    server_app.world.send_event(ToClients {
+        mode: SendMode::Broadcast,
+        event: DummyEvent,
+    });
+
+    // 5. Update clients to recieve the event.
+    // - If any client does not have a replicon tick >= the change tick associated with this event, then they
+    //   will not receive the event until their replicon tick is updated.
+    server_app.update();
+    client_app1.update();
+    client_app2.update();
+
+    assert_eq!(client_app1.world.resource::<Events<DummyEvent>>().len(), 1);
+    assert_eq!(client_app2.world.resource::<Events<DummyEvent>>().len(), 1);
+}
+
 #[derive(Component, Serialize, Deserialize)]
 struct DummyComponent;
 


### PR DESCRIPTION
This is a test for [this line](https://github.com/lifescapegame/bevy_replicon/blob/b98814a4adc7b4a0fa4a4bc9a99512bf786e1c8d/src/server/replication_messages.rs#L86), which only identifies init messages for the oldest connected client. It turns out that approach is technically correct for setting the `LastChangedTick` because the last changed tick can safely equal `max(last tick with init for replicated entity, oldest client connection tick)`.

This test will fail if you change that line to:
```rust
if let Some((init_message, _)) = self.data.last() {
```

We need to be sure this works correctly, otherwise a server-sent event (or component update) can hang on an older client if sent after a new client connects and there are no 'normal' init messages for a long time.
