### PR TITLE
Don't panic on race condition in client info updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `NetworkChannels` channel-creation methods public (`create_client_channel()` and `create_server_channel()`).
 - Implement `Eq` and `PartialEq` on `EventType`.
 
+### Fixed
+
+- Don't panic when handling client acks if the ack references a despawned entity.
+
 ## [0.19.0] - 2024-01-07
 
 ### Added

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-pub(super) mod clients_info;
+pub mod clients_info;
 pub(super) mod despawn_buffer;
 pub(super) mod removal_buffer;
 pub(super) mod replicated_archetypes_info;
@@ -341,9 +341,8 @@ fn collect_changes(
                             component,
                         )?;
                     } else {
-                        let tick = *client_info
-                            .ticks
-                            .get(&entity.entity())
+                        let tick = client_info
+                            .get_change_limit(entity.entity())
                             .expect("entity should be present after adding component");
                         if ticks.is_changed(tick, change_tick.this_run()) {
                             update_message.write_component(
@@ -363,9 +362,7 @@ fn collect_changes(
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.
                     init_message.take_entity_data(update_message)?;
-                    client_info
-                        .ticks
-                        .insert(entity.entity(), change_tick.this_run());
+                    client_info.set_change_limit(entity.entity(), change_tick.this_run());
                 } else {
                     update_message.end_entity_data()?;
                 }
@@ -425,7 +422,7 @@ fn collect_despawns(
     for entity in despawn_buffer.drain(..) {
         let mut shared_bytes = None;
         for (message, _, client_info) in messages.iter_mut_with_info() {
-            client_info.ticks.remove(&entity);
+            client_info.remove_despawned(entity);
             message.write_entity(&mut shared_bytes, entity)?;
         }
     }
@@ -451,7 +448,7 @@ fn collect_removals(
         for (message, _, client_info) in messages.iter_mut_with_info() {
             message.start_entity_data(entity);
             for &replication_id in components {
-                client_info.ticks.insert(entity, tick);
+                client_info.set_change_limit(entity, tick);
                 message.write_replication_id(replication_id)?;
             }
             message.end_entity_data(false)?;

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -7,6 +7,10 @@ use bevy::{
 };
 use bevy_renet::renet::ClientId;
 
+/// Stores meta-information about connected clients.
+#[derive(Default, Resource)]
+pub struct ClientsInfo(Vec<ClientInfo>);
+
 /// Reusable buffers for [`ClientsInfo`] and [`ClientInfo`].
 #[derive(Default, Resource)]
 pub(crate) struct ClientBuffers {
@@ -20,10 +24,6 @@ pub(crate) struct ClientBuffers {
     /// Stored to reuse allocated capacity.
     entities: Vec<Vec<Entity>>,
 }
-
-/// Stores meta-information about connected clients.
-#[derive(Default, Resource)]
-pub struct ClientsInfo(Vec<ClientInfo>);
 
 impl ClientsInfo {
     /// Returns a mutable iterator over clients information.

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -9,7 +9,7 @@ use bevy_renet::renet::ClientId;
 
 /// Stores meta-information about connected clients.
 #[derive(Default, Resource)]
-pub struct ClientsInfo(Vec<ClientInfo>);
+pub(crate) struct ClientsInfo(Vec<ClientInfo>);
 
 /// Reusable buffers for [`ClientsInfo`] and [`ClientInfo`].
 #[derive(Default, Resource)]
@@ -27,7 +27,7 @@ pub(crate) struct ClientBuffers {
 
 impl ClientsInfo {
     /// Returns a mutable iterator over clients information.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ClientInfo> {
+    pub(super) fn iter_mut(&mut self) -> impl Iterator<Item = &mut ClientInfo> {
         self.0.iter_mut()
     }
 
@@ -75,7 +75,7 @@ impl ClientsInfo {
     }
 }
 
-pub struct ClientInfo {
+pub(super) struct ClientInfo {
     id: ClientId,
     pub(super) just_connected: bool,
     ticks: EntityHashMap<Entity, Tick>,
@@ -204,8 +204,8 @@ impl ClientInfo {
     /// Removes a despawned entity tracked by this client.
     pub fn remove_despawned(&mut self, entity: Entity) {
         self.ticks.remove(&entity);
-        // We don't clean up `self.updates` for efficiency reasons. Self::acknowledge() will properly
-        // ignore despawned entities.
+        // We don't clean up `self.updates` for efficiency reasons.
+        // `Self::acknowledge()` will properly ignore despawned entities.
     }
 
     /// Removes all updates older then `min_timestamp`.

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -2,6 +2,7 @@ mod connect;
 
 use bevy::{prelude::*, utils::Duration};
 use bevy_replicon::{prelude::*, scene};
+use bevy_replicon::server::clients_info::ClientsInfo;
 
 use bevy_renet::renet::{
     transport::{NetcodeClientTransport, NetcodeServerTransport},
@@ -433,6 +434,72 @@ fn update_replication() {
         .query::<&BoolComponent>()
         .single(&client_app.world);
     assert!(component.0);
+}
+
+#[test]
+fn update_and_removal_with_stale_ack_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<BoolComponent>();
+    }
+
+    // 1. Connect a client.
+    connect::single_client(&mut server_app, &mut client_app);
+
+    // 2. Spawn an entity and replicate it to the client.
+    let server_entity = server_app
+        .world
+        .spawn((Replication, BoolComponent(false)))
+        .id();
+
+    server_app.update();
+    client_app.update();
+
+    assert_eq!(client_app.world.entities().len(), 1);
+
+    // 3. Update the component and replicate it to the client.
+    // - The client will send an update ack.
+    let mut component = server_app
+        .world
+        .get_mut::<BoolComponent>(server_entity)
+        .unwrap();
+    component.0 = true;
+
+    server_app.update();
+    client_app.update();
+
+    let component = client_app
+        .world
+        .query::<&BoolComponent>()
+        .single(&client_app.world);
+    assert!(component.0);
+
+    // 4. Despawn the entity.
+    server_app
+        .world
+        .entity_mut(server_entity)
+        .despawn();
+
+    // 5. Detect the despawn before collecting the client ack.
+    // - Due to networking race conditions we need to do this manually.
+    server_app.world.resource_mut::<ClientsInfo>().iter_mut().next().unwrap().remove_despawned(server_entity);
+
+    // 6. Collect entity acks from the client and send the desapwn to the client.
+    // - Entity acks should be ignored for the despawned entity.
+    server_app.update();
+
+    // 7. Update the client
+    client_app.update();
+
+    assert_eq!(client_app.world.entities().len(), 0);
 }
 
 #[test]

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -1,8 +1,8 @@
 mod connect;
 
 use bevy::{prelude::*, utils::Duration};
-use bevy_replicon::{prelude::*, scene};
 use bevy_replicon::server::clients_info::ClientsInfo;
+use bevy_replicon::{prelude::*, scene};
 
 use bevy_renet::renet::{
     transport::{NetcodeClientTransport, NetcodeServerTransport},
@@ -483,14 +483,17 @@ fn update_and_removal_with_stale_ack_replication() {
     assert!(component.0);
 
     // 4. Despawn the entity.
-    server_app
-        .world
-        .entity_mut(server_entity)
-        .despawn();
+    server_app.world.entity_mut(server_entity).despawn();
 
     // 5. Detect the despawn before collecting the client ack.
     // - Due to networking race conditions we need to do this manually.
-    server_app.world.resource_mut::<ClientsInfo>().iter_mut().next().unwrap().remove_despawned(server_entity);
+    server_app
+        .world
+        .resource_mut::<ClientsInfo>()
+        .iter_mut()
+        .next()
+        .unwrap()
+        .remove_despawned(server_entity);
 
     // 6. Collect entity acks from the client and send the desapwn to the client.
     // - Entity acks should be ignored for the despawned entity.


### PR DESCRIPTION
This line would panic erroneously due to a race condition between despawns and client acks: `.expect("tick should be inserted on any component insertion");`.

I moved the implementation details of `ClientInfo` inside its impl. One reason this bug occurred is the implementation logic was not self-contained so it was hard to reason about.