### PR TITLE
Clients visibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,8 +432,9 @@ pub mod prelude {
             NetworkChannels, ReplicationChannel, RepliconCorePlugin,
         },
         server::{
-            clients_info::ClientsInfo, has_authority, ClientEntityMap, ClientMapping, ServerPlugin,
-            ServerSet, TickPolicy, SERVER_ID,
+            clients_info::{client_visibility::ClientVisibility, ClientInfo, ClientsInfo},
+            has_authority, ClientEntityMap, ClientMapping, ServerPlugin, ServerSet, TickPolicy,
+            SERVER_ID,
         },
         ReplicationPlugins,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ pub mod prelude {
         server::{
             clients_info::{client_visibility::ClientVisibility, ClientInfo, ClientsInfo},
             has_authority, ClientEntityMap, ClientMapping, ServerPlugin, ServerSet, TickPolicy,
-            SERVER_ID,
+            VisibilityPolicy, SERVER_ID,
         },
         ReplicationPlugins,
     };

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -323,10 +323,7 @@ pub fn send_with<T>(
         }
         SendMode::Direct(client_id) => {
             if client_id != SERVER_ID {
-                if let Some(client_info) = clients_info
-                    .iter()
-                    .find(|client_info| client_info.id() == client_id)
-                {
+                if let Some(client_info) = clients_info.get(client_id) {
                     let message = serialize_with(client_info, None, &serialize_fn)?;
                     server.send_message(client_info.id(), channel, message.bytes);
                 }

--- a/src/network_event/server_event.rs
+++ b/src/network_event/server_event.rs
@@ -323,7 +323,7 @@ pub fn send_with<T>(
         }
         SendMode::Direct(client_id) => {
             if client_id != SERVER_ID {
-                if let Some(client_info) = clients_info.get(client_id) {
+                if let Some(client_info) = clients_info.get_client(client_id) {
                     let message = serialize_with(client_info, None, &serialize_fn)?;
                     server.send_message(client_info.id(), channel, message.bytes);
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,7 @@ use bevy_renet::{
 use crate::replicon_core::{
     replication_rules::ReplicationRules, replicon_tick::RepliconTick, ReplicationChannel,
 };
-use clients_info::{client_visibility::EntityVisibility, ClientBuffers, ClientInfo, ClientsInfo};
+use clients_info::{client_visibility::VisibilityInfo, ClientBuffers, ClientInfo, ClientsInfo};
 use despawn_buffer::{DespawnBuffer, DespawnBufferPlugin};
 use removal_buffer::{RemovalBuffer, RemovalBufferPlugin};
 use replicated_archetypes_info::ReplicatedArchetypesInfo;
@@ -330,8 +330,8 @@ fn collect_changes(
 
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                    let visibility = client_info.visibility().get(entity.entity());
-                    let new_entity = marker_added || visibility == EntityVisibility::Gained;
+                    let visibility = client_info.visibility().get_info(entity.entity());
+                    let new_entity = marker_added || visibility == VisibilityInfo::Gained;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
@@ -340,7 +340,7 @@ fn collect_changes(
                             component_info.replication_id,
                             component,
                         )?;
-                    } else if visibility == EntityVisibility::Maintained {
+                    } else if visibility == VisibilityInfo::Maintained {
                         let tick = client_info
                             .get_change_limit(entity.entity())
                             .expect("entity should be present after adding component");
@@ -357,8 +357,8 @@ fn collect_changes(
             }
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                let visibility = client_info.visibility().get(entity.entity());
-                let new_entity = marker_added || visibility == EntityVisibility::Gained;
+                let visibility = client_info.visibility().get_info(entity.entity());
+                let new_entity = marker_added || visibility == VisibilityInfo::Gained;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.

--- a/src/server.rs
+++ b/src/server.rs
@@ -522,9 +522,9 @@ pub enum VisibilityPolicy {
     /// All entities are visible by default and visibility can't be changed.
     #[default]
     All,
-    /// All entities are hidden by default and should be explicitly marked to be visible.
+    /// All entities are hidden by default and should be explicitly registered to be visible.
     Blacklist,
-    /// All entities are visible by default and should be explicitly marked to be hidden.
+    /// All entities are visible by default and should be explicitly registered to be hidden.
     Whitelist,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -516,7 +516,7 @@ pub enum TickPolicy {
     Manual,
 }
 
-/// Controls how visibility will be controlled via [`ClientVisibility`](clients_info::client_visibility::ClientVisibility).
+/// Controls how visibility will be managed via [`ClientVisibility`](clients_info::client_visibility::ClientVisibility).
 #[derive(Default, Debug, Clone, Copy)]
 pub enum VisibilityPolicy {
     /// All entities are visible by default and visibility can't be changed.

--- a/src/server.rs
+++ b/src/server.rs
@@ -507,7 +507,7 @@ pub enum TickPolicy {
     Manual,
 }
 
-/// Controls how visibility will be controlled via [`EntitiesVisibility`](entities_visibility::EntitiesVisibility).
+/// Controls how visibility will be controlled via [`ClientVisibility`](clients_info::client_visibility::ClientVisibility).
 #[derive(Default, Debug, Clone, Copy)]
 pub enum VisibilityPolicy {
     /// All entities are visible by default and visibility can't be changed.

--- a/src/server.rs
+++ b/src/server.rs
@@ -431,9 +431,7 @@ fn collect_despawns(
         for entity in client_info.remove_lost_visibility() {
             message.write_entity(&mut None, entity)?;
         }
-    }
 
-    for (message, _) in messages.iter_mut() {
         message.end_array()?;
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,7 @@ use bevy_renet::{
 use crate::replicon_core::{
     replication_rules::ReplicationRules, replicon_tick::RepliconTick, ReplicationChannel,
 };
-use clients_info::{client_visibility::VisibilityInfo, ClientBuffers, ClientInfo, ClientsInfo};
+use clients_info::{client_visibility::EntityState, ClientBuffers, ClientInfo, ClientsInfo};
 use despawn_buffer::{DespawnBuffer, DespawnBufferPlugin};
 use removal_buffer::{RemovalBuffer, RemovalBufferPlugin};
 use replicated_archetypes_info::ReplicatedArchetypesInfo;
@@ -295,9 +295,12 @@ fn collect_changes(
         };
 
         for entity in archetype.entities() {
-            for (init_message, update_message) in messages.iter_mut() {
+            for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                 init_message.start_entity_data(entity.entity());
                 update_message.start_entity_data(entity.entity());
+                client_info
+                    .visibility_mut()
+                    .read_entity_state(entity.entity());
             }
 
             // SAFETY: all replicated archetypes have marker component with table storage.
@@ -330,8 +333,8 @@ fn collect_changes(
 
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                    let visibility = client_info.visibility().get_info(entity.entity());
-                    let new_entity = marker_added || visibility == VisibilityInfo::Gained;
+                    let entity_state = client_info.visibility().entity_state();
+                    let new_entity = marker_added || entity_state == EntityState::JustVisible;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
@@ -340,7 +343,7 @@ fn collect_changes(
                             component_info.replication_id,
                             component,
                         )?;
-                    } else if visibility == VisibilityInfo::Maintained {
+                    } else if entity_state == EntityState::Visible {
                         let tick = client_info
                             .get_change_limit(entity.entity())
                             .expect("entity should be present after adding component");
@@ -357,8 +360,8 @@ fn collect_changes(
             }
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                let visibility = client_info.visibility().get_info(entity.entity());
-                let new_entity = marker_added || visibility == VisibilityInfo::Gained;
+                let entity_state = client_info.visibility().entity_state();
+                let new_entity = marker_added || entity_state == EntityState::JustVisible;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.

--- a/src/server.rs
+++ b/src/server.rs
@@ -331,7 +331,7 @@ fn collect_changes(
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                     let visibility = client_info.visibility().get(entity.entity());
-                    let new_entity = marker_added || visibility == EntityVisibility::JustVisible;
+                    let new_entity = marker_added || visibility == EntityVisibility::Gained;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
@@ -340,7 +340,7 @@ fn collect_changes(
                             component_info.replication_id,
                             component,
                         )?;
-                    } else if visibility == EntityVisibility::Visible {
+                    } else if visibility == EntityVisibility::Maintained {
                         let tick = client_info
                             .get_change_limit(entity.entity())
                             .expect("entity should be present after adding component");
@@ -358,7 +358,7 @@ fn collect_changes(
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                 let visibility = client_info.visibility().get(entity.entity());
-                let new_entity = marker_added || visibility == EntityVisibility::JustVisible;
+                let new_entity = marker_added || visibility == EntityVisibility::Gained;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.
@@ -428,7 +428,7 @@ fn collect_despawns(
     }
 
     for (message, _, client_info) in messages.iter_mut_with_info() {
-        for entity in client_info.remove_hidden() {
+        for entity in client_info.remove_lost_visibility() {
             message.write_entity(&mut None, entity)?;
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -439,7 +439,7 @@ fn collect_despawns(
     }
 
     for (message, _, client_info) in messages.iter_mut_with_info() {
-        for entity in client_info.remove_lost_visibility() {
+        for entity in client_info.drain_lost_visibility() {
             message.write_entity(&mut None, entity)?;
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -334,6 +334,10 @@ fn collect_changes(
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                     let entity_state = client_info.visibility().entity_state();
+                    if entity_state == EntityState::Hidden {
+                        continue;
+                    }
+
                     let new_entity = marker_added || entity_state == EntityState::JustVisible;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
@@ -343,7 +347,7 @@ fn collect_changes(
                             component_info.replication_id,
                             component,
                         )?;
-                    } else if entity_state == EntityState::Visible {
+                    } else {
                         let tick = client_info
                             .get_change_limit(entity.entity())
                             .expect("entity should be present after adding component");
@@ -361,6 +365,10 @@ fn collect_changes(
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                 let entity_state = client_info.visibility().entity_state();
+                if entity_state == EntityState::Hidden {
+                    continue;
+                }
+
                 let new_entity = marker_added || entity_state == EntityState::JustVisible;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message

--- a/src/server.rs
+++ b/src/server.rs
@@ -300,7 +300,7 @@ fn collect_changes(
                 update_message.start_entity_data(entity.entity());
                 client_info
                     .visibility_mut()
-                    .read_entity_state(entity.entity());
+                    .cache_visibility(entity.entity());
             }
 
             // SAFETY: all replicated archetypes have marker component with table storage.
@@ -333,12 +333,12 @@ fn collect_changes(
 
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                    let entity_state = client_info.visibility().entity_state();
-                    if entity_state == Visibility::Hidden {
+                    let visibility = client_info.visibility().cached_visibility();
+                    if visibility == Visibility::Hidden {
                         continue;
                     }
 
-                    let new_entity = marker_added || entity_state == Visibility::Gained;
+                    let new_entity = marker_added || visibility == Visibility::Gained;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
@@ -364,12 +364,12 @@ fn collect_changes(
             }
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
-                let entity_state = client_info.visibility().entity_state();
-                if entity_state == Visibility::Hidden {
+                let visibility = client_info.visibility().cached_visibility();
+                if visibility == Visibility::Hidden {
                     continue;
                 }
 
-                let new_entity = marker_added || entity_state == Visibility::Gained;
+                let new_entity = marker_added || visibility == Visibility::Gained;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.

--- a/src/server.rs
+++ b/src/server.rs
@@ -27,7 +27,7 @@ use bevy_renet::{
 use crate::replicon_core::{
     replication_rules::ReplicationRules, replicon_tick::RepliconTick, ReplicationChannel,
 };
-use clients_info::{client_visibility::EntityState, ClientBuffers, ClientInfo, ClientsInfo};
+use clients_info::{client_visibility::Visibility, ClientBuffers, ClientInfo, ClientsInfo};
 use despawn_buffer::{DespawnBuffer, DespawnBufferPlugin};
 use removal_buffer::{RemovalBuffer, RemovalBufferPlugin};
 use replicated_archetypes_info::ReplicatedArchetypesInfo;
@@ -334,11 +334,11 @@ fn collect_changes(
                 let mut shared_bytes = None;
                 for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                     let entity_state = client_info.visibility().entity_state();
-                    if entity_state == EntityState::Hidden {
+                    if entity_state == Visibility::Hidden {
                         continue;
                     }
 
-                    let new_entity = marker_added || entity_state == EntityState::JustVisible;
+                    let new_entity = marker_added || entity_state == Visibility::Gained;
                     if new_entity || ticks.is_added(change_tick.last_run(), change_tick.this_run())
                     {
                         init_message.write_component(
@@ -365,11 +365,11 @@ fn collect_changes(
 
             for (init_message, update_message, client_info) in messages.iter_mut_with_info() {
                 let entity_state = client_info.visibility().entity_state();
-                if entity_state == EntityState::Hidden {
+                if entity_state == Visibility::Hidden {
                     continue;
                 }
 
-                let new_entity = marker_added || entity_state == EntityState::JustVisible;
+                let new_entity = marker_added || entity_state == Visibility::Gained;
                 if new_entity || init_message.entity_data_size() != 0 {
                     // If there is any insertion or we must initialize, include all updates into init message
                     // and bump the last acknowledged tick to keep entity updates atomic.

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -48,7 +48,7 @@ impl ClientsInfo {
     ///
     /// # Panics
     ///
-    /// Panics if passed client ID is not connected.
+    /// Panics if the passed client ID is not connected.
     pub fn client(&self, client_id: ClientId) -> &ClientInfo {
         self.get_client(client_id)
             .unwrap_or_else(|| panic!("{client_id:?} should be connected"))
@@ -61,7 +61,7 @@ impl ClientsInfo {
     ///
     /// # Panics
     ///
-    /// Panics if passed client ID is not connected.
+    /// Panics if the passed client ID is not connected.
     pub fn client_mut(&mut self, client_id: ClientId) -> &mut ClientInfo {
         self.get_client_mut(client_id)
             .unwrap_or_else(|| panic!("{client_id:?} should be connected"))

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -304,11 +304,11 @@ impl ClientInfo {
         // `Self::acknowledge()` will properly ignore despawned entities.
     }
 
-    /// Iterates over all entities for which visibility was lost during this tick and removes them.
+    /// Drains all entities for which visibility was lost during this tick.
     ///
-    /// Removal happens lazily during the iteration.
-    pub(super) fn remove_lost_visibility(&mut self) -> impl Iterator<Item = Entity> + '_ {
-        self.visibility.iter_lost_visibility().inspect(|entity| {
+    /// Internal cleanup happens lazily during the iteration.
+    pub(super) fn drain_lost_visibility(&mut self) -> impl Iterator<Item = Entity> + '_ {
+        self.visibility.drain_lost_visibility().inspect(|entity| {
             self.ticks.remove(entity);
         })
     }

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -41,10 +41,16 @@ impl ClientsInfo {
         }
     }
 
+    /// Returns reference to connected client info.
+    ///
+    /// This operation is *O*(*n*).
     pub fn get(&self, client_id: ClientId) -> Option<&ClientInfo> {
         self.info.iter().find(|info| info.id == client_id)
     }
 
+    /// Returns mutable reference to connected client info.
+    ///
+    /// This operation is *O*(*n*).
     pub fn get_mut(&mut self, client_id: ClientId) -> Option<&mut ClientInfo> {
         self.info.iter_mut().find(|info| info.id == client_id)
     }
@@ -64,6 +70,7 @@ impl ClientsInfo {
         self.info.len()
     }
 
+    /// Returns `true` if no clients connected.
     pub fn is_empty(&self) -> bool {
         self.info.is_empty()
     }
@@ -148,12 +155,14 @@ impl ClientInfo {
         self.id
     }
 
-    pub fn visibility_mut(&mut self) -> &mut ClientVisibility {
-        &mut self.visibility
-    }
-
+    /// Returns reference to client visibility settings.
     pub fn visibility(&self) -> &ClientVisibility {
         &self.visibility
+    }
+
+    /// Returns mutable reference to client visibility settings.
+    pub fn visibility_mut(&mut self) -> &mut ClientVisibility {
+        &mut self.visibility
     }
 
     /// Clears all entities for unacknowledged updates, returning them as an iterator.
@@ -266,6 +275,9 @@ impl ClientInfo {
         // `Self::acknowledge()` will properly ignore despawned entities.
     }
 
+    /// Iterates over all entities for which visibility was lost during this tick and removes them.
+    ///
+    /// Removal happens lazily during the iteration.
     pub(super) fn remove_lost_visibility(&mut self) -> impl Iterator<Item = Entity> + '_ {
         self.visibility.iter_lost_visibility().inspect(|entity| {
             self.ticks.remove(entity);

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -44,14 +44,42 @@ impl ClientsInfo {
     /// Returns a reference to a connected client's info.
     ///
     /// This operation is *O*(*n*).
-    pub fn get(&self, client_id: ClientId) -> Option<&ClientInfo> {
+    /// See also [`Self::get_client`] for the fallible version.
+    ///
+    /// # Panics
+    ///
+    /// Panics if passed client ID is not connected.
+    pub fn client(&self, client_id: ClientId) -> &ClientInfo {
+        self.get_client(client_id)
+            .unwrap_or_else(|| panic!("{client_id:?} should be connected"))
+    }
+
+    /// Returns a mutable reference to a connected client's info.
+    ///
+    /// This operation is *O*(*n*).
+    /// See also [`Self::get_client_mut`] for the fallible version.
+    ///
+    /// # Panics
+    ///
+    /// Panics if passed client ID is not connected.
+    pub fn client_mut(&mut self, client_id: ClientId) -> &mut ClientInfo {
+        self.get_client_mut(client_id)
+            .unwrap_or_else(|| panic!("{client_id:?} should be connected"))
+    }
+
+    /// Returns a reference to a connected client's info.
+    ///
+    /// This operation is *O*(*n*).
+    /// See also [`Self::client`] for the panicking version.
+    pub fn get_client(&self, client_id: ClientId) -> Option<&ClientInfo> {
         self.info.iter().find(|info| info.id == client_id)
     }
 
     /// Returns a mutable reference to a connected client's info.
     ///
     /// This operation is *O*(*n*).
-    pub fn get_mut(&mut self, client_id: ClientId) -> Option<&mut ClientInfo> {
+    /// See also [`Self::client`] for the panicking version.
+    pub fn get_client_mut(&mut self, client_id: ClientId) -> Option<&mut ClientInfo> {
         self.info.iter_mut().find(|info| info.id == client_id)
     }
 

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -266,8 +266,8 @@ impl ClientInfo {
         // `Self::acknowledge()` will properly ignore despawned entities.
     }
 
-    pub(super) fn remove_hidden(&mut self) -> impl Iterator<Item = Entity> + '_ {
-        self.visibility.iter_hidden().inspect(|entity| {
+    pub(super) fn remove_lost_visibility(&mut self) -> impl Iterator<Item = Entity> + '_ {
+        self.visibility.iter_lost_visibility().inspect(|entity| {
             self.ticks.remove(entity);
         })
     }

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -48,29 +48,29 @@ impl ClientsInfo {
         self.info.iter().find(|info| info.id == client_id)
     }
 
-    /// Returns mutable reference to connected client info.
+    /// Returns a mutable reference to a connected client's info.
     ///
     /// This operation is *O*(*n*).
     pub fn get_mut(&mut self, client_id: ClientId) -> Option<&mut ClientInfo> {
         self.info.iter_mut().find(|info| info.id == client_id)
     }
 
-    /// Returns an iterator over clients information.
+    /// Returns an iterator over client information.
     pub fn iter(&self) -> impl Iterator<Item = &ClientInfo> {
         self.info.iter()
     }
 
-    /// Returns a mutable iterator over clients information.
+    /// Returns a mutable iterator over client information.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ClientInfo> {
         self.info.iter_mut()
     }
 
-    /// Returns number of connected clients.
+    /// Returns the number of connected clients.
     pub fn len(&self) -> usize {
         self.info.len()
     }
 
-    /// Returns `true` if no clients connected.
+    /// Returns `true` if no clients are connected.
     pub fn is_empty(&self) -> bool {
         self.info.is_empty()
     }
@@ -156,12 +156,12 @@ impl ClientInfo {
         self.id
     }
 
-    /// Returns reference to client visibility settings.
+    /// Returns a reference to the client's visibility settings.
     pub fn visibility(&self) -> &ClientVisibility {
         &self.visibility
     }
 
-    /// Returns mutable reference to client visibility settings.
+    /// Returns a mutable reference to the client's visibility settings.
     pub fn visibility_mut(&mut self) -> &mut ClientVisibility {
         &mut self.visibility
     }

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -121,6 +121,7 @@ pub struct ClientInfo {
     /// Lowest tick for use in change detection for each entity.
     ticks: EntityHashMap<Entity, Tick>,
 
+    /// Entity visibility settings.
     visibility: ClientVisibility,
 
     /// The last tick in which a replicated entity was spawned, despawned, or gained/lost a component from the perspective

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -1,3 +1,5 @@
+pub mod client_visibility;
+
 use std::mem;
 
 use bevy::{
@@ -7,11 +9,15 @@ use bevy::{
 };
 use bevy_renet::renet::ClientId;
 
-use crate::replicon_core::replicon_tick::RepliconTick;
+use crate::{replicon_core::replicon_tick::RepliconTick, server::VisibilityPolicy};
+use client_visibility::ClientVisibility;
 
 /// Stores meta-information about connected clients.
-#[derive(Default, Resource)]
-pub struct ClientsInfo(Vec<ClientInfo>);
+#[derive(Resource, Default)]
+pub struct ClientsInfo {
+    info: Vec<ClientInfo>,
+    policy: VisibilityPolicy,
+}
 
 /// Reusable buffers for [`ClientsInfo`] and [`ClientInfo`].
 #[derive(Default, Resource)]
@@ -28,19 +34,38 @@ pub(crate) struct ClientBuffers {
 }
 
 impl ClientsInfo {
+    pub(super) fn new(policy: VisibilityPolicy) -> Self {
+        Self {
+            info: Default::default(),
+            policy,
+        }
+    }
+
+    pub fn get(&self, client_id: ClientId) -> Option<&ClientInfo> {
+        self.info.iter().find(|info| info.id == client_id)
+    }
+
+    pub fn get_mut(&mut self, client_id: ClientId) -> Option<&mut ClientInfo> {
+        self.info.iter_mut().find(|info| info.id == client_id)
+    }
+
     /// Returns an iterator over clients information.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &ClientInfo> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = &ClientInfo> {
+        self.info.iter()
     }
 
     /// Returns a mutable iterator over clients information.
-    pub(super) fn iter_mut(&mut self) -> impl Iterator<Item = &mut ClientInfo> {
-        self.0.iter_mut()
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut ClientInfo> {
+        self.info.iter_mut()
     }
 
     /// Returns number of connected clients.
-    pub(super) fn len(&self) -> usize {
-        self.0.len()
+    pub fn len(&self) -> usize {
+        self.info.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.info.is_empty()
     }
 
     /// Initializes a new [`ClientInfo`] for this client.
@@ -51,10 +76,10 @@ impl ClientsInfo {
             client_info.reset(client_id);
             client_info
         } else {
-            ClientInfo::new(client_id)
+            ClientInfo::new(client_id, self.policy)
         };
 
-        self.0.push(client_info);
+        self.info.push(client_info);
     }
 
     /// Removes info for the client.
@@ -62,11 +87,11 @@ impl ClientsInfo {
     /// Keeps allocated memory in the buffers for reuse.
     pub(super) fn remove(&mut self, client_buffers: &mut ClientBuffers, client_id: ClientId) {
         let index = self
-            .0
+            .info
             .iter()
             .position(|info| info.id == client_id)
             .expect("clients info should contain all connected clients");
-        let mut client_info = self.0.remove(index);
+        let mut client_info = self.info.remove(index);
         client_buffers.entities.extend(client_info.drain_entities());
         client_buffers.info.push(client_info);
     }
@@ -75,22 +100,21 @@ impl ClientsInfo {
     ///
     /// Keeps allocated memory in the buffers for reuse.
     pub(super) fn clear(&mut self, client_buffers: &mut ClientBuffers) {
-        for mut client_info in self.0.drain(..) {
+        for mut client_info in self.info.drain(..) {
             client_buffers.entities.extend(client_info.drain_entities());
             client_buffers.info.push(client_info);
         }
     }
 }
 
-pub(crate) struct ClientInfo {
+pub struct ClientInfo {
     /// Client's ID.
     id: ClientId,
 
-    /// Indicates whether the client connected in this tick.
-    pub(super) just_connected: bool,
-
     /// Lowest tick for use in change detection for each entity.
     ticks: EntityHashMap<Entity, Tick>,
+
+    visibility: ClientVisibility,
 
     /// The last tick in which a replicated entity was spawned, despawned, or gained/lost a component from the perspective
     /// of the client.
@@ -108,11 +132,11 @@ pub(crate) struct ClientInfo {
 }
 
 impl ClientInfo {
-    fn new(id: ClientId) -> Self {
+    fn new(id: ClientId, policy: VisibilityPolicy) -> Self {
         Self {
             id,
-            just_connected: true,
             ticks: Default::default(),
+            visibility: ClientVisibility::new(policy),
             change_tick: Default::default(),
             updates: Default::default(),
             next_update_index: Default::default(),
@@ -122,6 +146,14 @@ impl ClientInfo {
     // Returns associated client ID.
     pub(crate) fn id(&self) -> ClientId {
         self.id
+    }
+
+    pub fn visibility_mut(&mut self) -> &mut ClientVisibility {
+        &mut self.visibility
+    }
+
+    pub fn visibility(&self) -> &ClientVisibility {
+        &self.visibility
     }
 
     /// Clears all entities for unacknowledged updates, returning them as an iterator.
@@ -138,7 +170,7 @@ impl ClientInfo {
     /// Keeps the allocated memory for reuse.
     fn reset(&mut self, id: ClientId) {
         self.id = id;
-        self.just_connected = true;
+        self.visibility.clear();
         self.ticks.clear();
         self.updates.clear();
         self.next_update_index = 0;
@@ -229,8 +261,15 @@ impl ClientInfo {
     /// Removes a despawned entity tracked by this client.
     pub fn remove_despawned(&mut self, entity: Entity) {
         self.ticks.remove(&entity);
+        self.visibility.remove_despawned(entity);
         // We don't clean up `self.updates` for efficiency reasons.
         // `Self::acknowledge()` will properly ignore despawned entities.
+    }
+
+    pub(super) fn remove_hidden(&mut self) -> impl Iterator<Item = Entity> + '_ {
+        self.visibility.iter_hidden().inspect(|entity| {
+            self.ticks.remove(entity);
+        })
     }
 
     /// Removes all updates older then `min_timestamp`.

--- a/src/server/clients_info.rs
+++ b/src/server/clients_info.rs
@@ -41,7 +41,7 @@ impl ClientsInfo {
         }
     }
 
-    /// Returns reference to connected client info.
+    /// Returns a reference to a connected client's info.
     ///
     /// This operation is *O*(*n*).
     pub fn get(&self, client_id: ClientId) -> Option<&ClientInfo> {

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -31,7 +31,7 @@ impl ClientVisibility {
         }
     }
 
-    /// Creates a new instance with specific filter.
+    /// Creates a new instance with a specific filter.
     fn with_filter(filter: VisibilityFilter) -> Self {
         Self {
             filter,
@@ -119,7 +119,7 @@ impl ClientVisibility {
         }
     }
 
-    /// Returns an iterator of entities that lost visibility at this tick.
+    /// Returns an iterator of entities the client lost visibility of this tick.
     pub(super) fn iter_lost_visibility(&self) -> impl Iterator<Item = Entity> + '_ {
         match &self.filter {
             VisibilityFilter::All { .. } => VisibilityLostIter::AllVisible,
@@ -132,9 +132,9 @@ impl ClientVisibility {
         }
     }
 
-    /// Sets visibility for specific entity.
+    /// Sets visibility for a specific entity.
     ///
-    /// Does nothing if visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
+    /// Does nothing if the visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
     pub fn set_visible(&mut self, entity: Entity, visibile: bool) {
         match &mut self.filter {
             VisibilityFilter::All { .. } => {
@@ -184,7 +184,7 @@ impl ClientVisibility {
         }
     }
 
-    /// Gets visibility for specific entity.
+    /// Gets visibility for a specific entity.
     pub fn is_visible(&self, entity: Entity) -> bool {
         match &self.filter {
             VisibilityFilter::All { .. } => true,

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -103,14 +103,8 @@ impl ClientVisibility {
                 list,
                 added,
                 removed,
-            } => {
-                if let Some(just_removed) = list.get_mut(&entity) {
-                    *just_removed = true;
-                    removed.remove(&entity);
-                    added.remove(&entity);
-                }
             }
-            VisibilityFilter::Whitelist {
+            | VisibilityFilter::Whitelist {
                 list,
                 added,
                 removed,

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -172,9 +172,12 @@ impl ClientVisibility {
                         removed.insert(entity);
                         added.remove(&entity);
                     }
-                } else if list.insert(entity, BlacklistInfo::Hidden).is_none() {
+                } else {
+                    if list.insert(entity, BlacklistInfo::Hidden).is_none() {
+                        // Do not mark an entry as newly added if the entry was already in the list.
+                        added.insert(entity);
+                    }
                     removed.remove(&entity);
-                    added.insert(entity);
                 }
             }
             VisibilityFilter::Whitelist {
@@ -184,9 +187,10 @@ impl ClientVisibility {
             } => {
                 if visibile {
                     if list.insert(entity, WhitelistInfo::JustAdded).is_none() {
-                        removed.remove(&entity);
+                        // Do not mark an entry as newly added if the entry was already in the list.
                         added.insert(entity);
                     }
+                    removed.remove(&entity);
                 } else if list.remove(&entity).is_some() {
                     removed.insert(entity);
                     added.remove(&entity);

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -231,19 +231,20 @@ enum VisibilityFilter {
         just_connected: bool,
     },
     Blacklist {
-        /// All blacklisted entities and an indicator of whether it is in the queue for deletion at this tick.
+        /// All blacklisted entities and an indicator of whether it is in the queue for deletion
+        /// at the end of this tick.
         list: EntityHashMap<Entity, bool>,
-        /// All entities that were removed from the list on this tick.
+        /// All entities that were removed from the list in this tick.
         added: EntityHashSet<Entity>,
-        /// All entities that were added to the list on this tick.
+        /// All entities that were added to the list in this tick.
         removed: EntityHashSet<Entity>,
     },
     Whitelist {
-        /// All whitelisted entities and an indicator whether it was added to the list on this tick.
+        /// All whitelisted entities and an indicator whether it was added to the list in this tick.
         list: EntityHashMap<Entity, bool>,
-        /// All entities that were added to the list on this tick.
+        /// All entities that were added to the list in this tick.
         added: EntityHashSet<Entity>,
-        /// All entities that were removed from the list on this tick.
+        /// All entities that were removed from the list in this tick.
         removed: EntityHashSet<Entity>,
     },
 }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -135,7 +135,7 @@ impl ClientVisibility {
     /// Sets visibility for a specific entity.
     ///
     /// Does nothing if the visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
-    pub fn set_visible(&mut self, entity: Entity, visibile: bool) {
+    pub fn set_visibility(&mut self, entity: Entity, visibile: bool) {
         match &mut self.filter {
             VisibilityFilter::All { .. } => {
                 if visibile {

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -160,7 +160,8 @@ impl ClientVisibility {
                         removed.remove(&entity);
                         added.insert(entity);
                     }
-                } else if list.remove(&entity).is_some() {
+                } else if let Some(just_removed) = list.get_mut(&entity) {
+                    *just_removed = true;
                     removed.insert(entity);
                     added.remove(&entity);
                 }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -1,0 +1,157 @@
+use std::iter;
+
+use bevy::{
+    prelude::*,
+    utils::{EntityHashMap, EntityHashSet},
+};
+
+use super::VisibilityPolicy;
+
+pub enum ClientVisibility {
+    All {
+        just_connected: bool,
+    },
+    Blacklist {
+        list: EntityHashMap<Entity, bool>,
+        removed: EntityHashSet<Entity>,
+    },
+    Whitelist {
+        list: EntityHashMap<Entity, bool>,
+        removed: EntityHashSet<Entity>,
+    },
+}
+
+impl ClientVisibility {
+    /// Creates a new instance based on the preconfigured policy.
+    pub(super) fn new(policy: VisibilityPolicy) -> Self {
+        match policy {
+            VisibilityPolicy::All => Self::All {
+                just_connected: true,
+            },
+            VisibilityPolicy::Blacklist => Self::Blacklist {
+                list: Default::default(),
+                removed: Default::default(),
+            },
+            VisibilityPolicy::Whitelist => Self::Whitelist {
+                list: Default::default(),
+                removed: Default::default(),
+            },
+        }
+    }
+
+    /// Resets the state to as it was after [`Self::new`].
+    pub(super) fn clear(&mut self) {
+        match self {
+            ClientVisibility::All { just_connected } => *just_connected = true,
+            ClientVisibility::Blacklist { list, removed }
+            | ClientVisibility::Whitelist { list, removed } => {
+                list.clear();
+                removed.clear();
+            }
+        }
+    }
+
+    /// Marks all entities as not "just added" and clears the removed.
+    ///
+    /// Should be called after each tick.
+    pub(crate) fn update(&mut self) {
+        match self {
+            ClientVisibility::All { just_connected } => *just_connected = false,
+            ClientVisibility::Blacklist { list, removed }
+            | ClientVisibility::Whitelist { list, removed } => {
+                for just_added in list.values_mut() {
+                    *just_added = false;
+                }
+                removed.clear();
+            }
+        }
+    }
+
+    pub(super) fn remove_despawned(&mut self, entity: Entity) {
+        match self {
+            ClientVisibility::All { .. } => (),
+            ClientVisibility::Blacklist { list, removed }
+            | ClientVisibility::Whitelist { list, removed } => {
+                list.remove(&entity);
+                removed.remove(&entity);
+            }
+        }
+    }
+
+    pub(super) fn iter_hidden(&self) -> Box<dyn Iterator<Item = Entity> + '_> {
+        match self {
+            ClientVisibility::All { .. } => Box::new(iter::empty()),
+            ClientVisibility::Blacklist { list, .. } => Box::new(
+                list.iter()
+                    .filter_map(|(&entity, just_added)| just_added.then_some(entity)),
+            ),
+            ClientVisibility::Whitelist { removed, .. } => Box::new(removed.iter().copied()),
+        }
+    }
+
+    /// Sets visibility for specific entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the server plugin was previously configured with [`VisibilityPolicy::All`].
+    pub fn set(&mut self, entity: Entity, visibile: bool) {
+        match self {
+            ClientVisibility::All { .. } => {
+                panic!(
+                    "visibility shouldn't be set with {:?}",
+                    VisibilityPolicy::All
+                )
+            }
+            ClientVisibility::Blacklist { list, removed } => {
+                if !visibile {
+                    list.insert(entity, true);
+                    removed.remove(&entity);
+                } else if list.remove(&entity).is_some() {
+                    removed.insert(entity);
+                }
+            }
+            ClientVisibility::Whitelist { list, removed } => {
+                if visibile {
+                    list.insert(entity, true);
+                    removed.remove(&entity);
+                } else if list.remove(&entity).is_some() {
+                    removed.insert(entity);
+                }
+            }
+        }
+    }
+
+    /// Gets visibility for specific entity.
+    pub fn get(&self, entity: Entity) -> EntityVisibility {
+        match self {
+            ClientVisibility::All { just_connected } => {
+                if *just_connected {
+                    EntityVisibility::JustVisible
+                } else {
+                    EntityVisibility::Visible
+                }
+            }
+            ClientVisibility::Blacklist { list, removed } => {
+                if list.contains_key(&entity) {
+                    EntityVisibility::Hidden
+                } else if removed.contains(&entity) {
+                    EntityVisibility::JustVisible
+                } else {
+                    EntityVisibility::Visible
+                }
+            }
+            ClientVisibility::Whitelist { list, .. } => match list.get(&entity) {
+                Some(true) => EntityVisibility::JustVisible,
+                Some(false) => EntityVisibility::Visible,
+                None => EntityVisibility::Hidden,
+            },
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum EntityVisibility {
+    JustVisible,
+    Visible,
+    Hidden,
+}

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -312,13 +312,4 @@ impl<T: Iterator> Iterator for VisibilityLostIter<T> {
             VisibilityLostIter::Lost(entities) => entities.next(),
         }
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            VisibilityLostIter::AllVisible => (0, Some(0)),
-            VisibilityLostIter::Lost(entities) => entities.size_hint(),
-        }
-    }
 }
-
-impl<T: ExactSizeIterator> ExactSizeIterator for VisibilityLostIter<T> {}

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -459,6 +459,8 @@ mod tests {
     #[test]
     fn blacklist_insertion_removal() {
         let mut visibility = ClientVisibility::new(VisibilityPolicy::Blacklist);
+
+        // Insert and remove from the list.
         visibility.set_visibility(Entity::PLACEHOLDER, false);
         visibility.set_visibility(Entity::PLACEHOLDER, true);
         assert!(visibility.is_visible(Entity::PLACEHOLDER));
@@ -574,6 +576,8 @@ mod tests {
     #[test]
     fn whitelist_insertion_removal() {
         let mut visibility = ClientVisibility::new(VisibilityPolicy::Whitelist);
+
+        // Insert and remove from the list.
         visibility.set_visibility(Entity::PLACEHOLDER, true);
         visibility.set_visibility(Entity::PLACEHOLDER, false);
         assert!(!visibility.is_visible(Entity::PLACEHOLDER));

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -7,16 +7,26 @@ use bevy::{
 
 use super::VisibilityPolicy;
 
+/// Entity visibility settings for a client.
 pub enum ClientVisibility {
     All {
+        /// Indicates that the client has just connected to the server.
         just_connected: bool,
     },
     Blacklist {
+        /// All blacklisted entities and an indicator of whether it is in the queue for deletion at this tick.
         list: EntityHashMap<Entity, bool>,
+        /// All entities that were removed from the list on this tick.
+        added: EntityHashSet<Entity>,
+        /// All entities that were added to the list on this tick.
         removed: EntityHashSet<Entity>,
     },
     Whitelist {
+        /// All whitelisted entities and an indicator whether it was added to the list on this tick.
         list: EntityHashMap<Entity, bool>,
+        /// All entities that were added to the list on this tick.
+        added: EntityHashSet<Entity>,
+        /// All entities that were removed from the list on this tick.
         removed: EntityHashSet<Entity>,
     },
 }
@@ -30,10 +40,12 @@ impl ClientVisibility {
             },
             VisibilityPolicy::Blacklist => Self::Blacklist {
                 list: Default::default(),
+                added: Default::default(),
                 removed: Default::default(),
             },
             VisibilityPolicy::Whitelist => Self::Whitelist {
                 list: Default::default(),
+                added: Default::default(),
                 removed: Default::default(),
             },
         }
@@ -43,9 +55,18 @@ impl ClientVisibility {
     pub(super) fn clear(&mut self) {
         match self {
             ClientVisibility::All { just_connected } => *just_connected = true,
-            ClientVisibility::Blacklist { list, removed }
-            | ClientVisibility::Whitelist { list, removed } => {
+            ClientVisibility::Blacklist {
+                list,
+                added,
+                removed,
+            }
+            | ClientVisibility::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
                 list.clear();
+                added.clear();
                 removed.clear();
             }
         }
@@ -57,34 +78,62 @@ impl ClientVisibility {
     pub(crate) fn update(&mut self) {
         match self {
             ClientVisibility::All { just_connected } => *just_connected = false,
-            ClientVisibility::Blacklist { list, removed }
-            | ClientVisibility::Whitelist { list, removed } => {
-                for just_added in list.values_mut() {
-                    *just_added = false;
+            ClientVisibility::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
+                for entity in removed.drain() {
+                    list.remove(&entity);
+                }
+                added.clear();
+            }
+            ClientVisibility::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                for entity in added.drain() {
+                    list.insert(entity, false);
                 }
                 removed.clear();
             }
         }
     }
 
+    /// Removes a despawned entity tracked by this client.
     pub(super) fn remove_despawned(&mut self, entity: Entity) {
         match self {
             ClientVisibility::All { .. } => (),
-            ClientVisibility::Blacklist { list, removed }
-            | ClientVisibility::Whitelist { list, removed } => {
-                list.remove(&entity);
-                removed.remove(&entity);
+            ClientVisibility::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
+                if let Some(just_removed) = list.get_mut(&entity) {
+                    *just_removed = true;
+                    removed.remove(&entity);
+                    added.remove(&entity);
+                }
+            }
+            ClientVisibility::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                if list.remove(&entity).is_some() {
+                    added.remove(&entity);
+                    removed.remove(&entity);
+                }
             }
         }
     }
 
+    /// Returns an iterator of entities that lost visibility at this tick.
     pub(super) fn iter_lost_visibility(&self) -> Box<dyn Iterator<Item = Entity> + '_> {
         match self {
             ClientVisibility::All { .. } => Box::new(iter::empty()),
-            ClientVisibility::Blacklist { list, .. } => Box::new(
-                list.iter()
-                    .filter_map(|(&entity, just_added)| just_added.then_some(entity)),
-            ),
+            ClientVisibility::Blacklist { added, .. } => Box::new(added.iter().copied()),
             ClientVisibility::Whitelist { removed, .. } => Box::new(removed.iter().copied()),
         }
     }
@@ -107,20 +156,34 @@ impl ClientVisibility {
                     );
                 }
             }
-            ClientVisibility::Blacklist { list, removed } => {
+            ClientVisibility::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
                 if !visibile {
-                    list.insert(entity, true);
-                    removed.remove(&entity);
+                    if list.insert(entity, false).is_none() {
+                        removed.remove(&entity);
+                        added.insert(entity);
+                    }
                 } else if list.remove(&entity).is_some() {
                     removed.insert(entity);
+                    added.remove(&entity);
                 }
             }
-            ClientVisibility::Whitelist { list, removed } => {
+            ClientVisibility::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
                 if visibile {
-                    list.insert(entity, true);
-                    removed.remove(&entity);
+                    if list.insert(entity, true).is_none() {
+                        removed.remove(&entity);
+                        added.insert(entity);
+                    }
                 } else if list.remove(&entity).is_some() {
                     removed.insert(entity);
+                    added.remove(&entity);
                 }
             }
         }
@@ -136,15 +199,11 @@ impl ClientVisibility {
                     EntityVisibility::Maintained
                 }
             }
-            ClientVisibility::Blacklist { list, removed } => {
-                if list.contains_key(&entity) {
-                    EntityVisibility::None
-                } else if removed.contains(&entity) {
-                    EntityVisibility::Gained
-                } else {
-                    EntityVisibility::Maintained
-                }
-            }
+            ClientVisibility::Blacklist { list, .. } => match list.get(&entity) {
+                Some(true) => EntityVisibility::Gained,
+                Some(false) => EntityVisibility::None,
+                None => EntityVisibility::Maintained,
+            },
             ClientVisibility::Whitelist { list, .. } => match list.get(&entity) {
                 Some(true) => EntityVisibility::Gained,
                 Some(false) => EntityVisibility::Maintained,

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -78,7 +78,7 @@ impl ClientVisibility {
         }
     }
 
-    pub(super) fn iter_hidden(&self) -> Box<dyn Iterator<Item = Entity> + '_> {
+    pub(super) fn iter_lost_visibility(&self) -> Box<dyn Iterator<Item = Entity> + '_> {
         match self {
             ClientVisibility::All { .. } => Box::new(iter::empty()),
             ClientVisibility::Blacklist { list, .. } => Box::new(
@@ -131,24 +131,24 @@ impl ClientVisibility {
         match self {
             ClientVisibility::All { just_connected } => {
                 if *just_connected {
-                    EntityVisibility::JustVisible
+                    EntityVisibility::Gained
                 } else {
-                    EntityVisibility::Visible
+                    EntityVisibility::Maintained
                 }
             }
             ClientVisibility::Blacklist { list, removed } => {
                 if list.contains_key(&entity) {
-                    EntityVisibility::Hidden
+                    EntityVisibility::None
                 } else if removed.contains(&entity) {
-                    EntityVisibility::JustVisible
+                    EntityVisibility::Gained
                 } else {
-                    EntityVisibility::Visible
+                    EntityVisibility::Maintained
                 }
             }
             ClientVisibility::Whitelist { list, .. } => match list.get(&entity) {
-                Some(true) => EntityVisibility::JustVisible,
-                Some(false) => EntityVisibility::Visible,
-                None => EntityVisibility::Hidden,
+                Some(true) => EntityVisibility::Gained,
+                Some(false) => EntityVisibility::Maintained,
+                None => EntityVisibility::None,
             },
         }
     }
@@ -156,7 +156,7 @@ impl ClientVisibility {
 
 #[derive(PartialEq)]
 pub enum EntityVisibility {
-    JustVisible,
-    Visible,
-    Hidden,
+    Gained,
+    Maintained,
+    None,
 }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -499,6 +499,7 @@ mod tests {
 
         // Duplicate insertion.
         visibility.set_visibility(Entity::PLACEHOLDER, false);
+        assert!(!visibility.is_visible(Entity::PLACEHOLDER));
 
         let VisibilityFilter::Blacklist {
             list,
@@ -639,6 +640,7 @@ mod tests {
 
         // Duplicate insertion.
         visibility.set_visibility(Entity::PLACEHOLDER, true);
+        assert!(visibility.is_visible(Entity::PLACEHOLDER));
 
         let VisibilityFilter::Whitelist {
             list,

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -6,7 +6,205 @@ use bevy::{
 use super::VisibilityPolicy;
 
 /// Entity visibility settings for a client.
-pub enum ClientVisibility {
+pub struct ClientVisibility(VisibilityFilter);
+
+impl ClientVisibility {
+    /// Creates a new instance based on the preconfigured policy.
+    pub(super) fn new(policy: VisibilityPolicy) -> Self {
+        match policy {
+            VisibilityPolicy::All => Self(VisibilityFilter::All {
+                just_connected: true,
+            }),
+            VisibilityPolicy::Blacklist => Self(VisibilityFilter::Blacklist {
+                list: Default::default(),
+                added: Default::default(),
+                removed: Default::default(),
+            }),
+            VisibilityPolicy::Whitelist => Self(VisibilityFilter::Whitelist {
+                list: Default::default(),
+                added: Default::default(),
+                removed: Default::default(),
+            }),
+        }
+    }
+
+    /// Resets the state to as it was after [`Self::new`].
+    pub(super) fn clear(&mut self) {
+        match &mut self.0 {
+            VisibilityFilter::All { just_connected } => *just_connected = true,
+            VisibilityFilter::Blacklist {
+                list,
+                added,
+                removed,
+            }
+            | VisibilityFilter::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                list.clear();
+                added.clear();
+                removed.clear();
+            }
+        }
+    }
+
+    /// Marks all entities as not "just added" and clears the removed.
+    ///
+    /// Should be called after each tick.
+    pub(crate) fn update(&mut self) {
+        match &mut self.0 {
+            VisibilityFilter::All { just_connected } => *just_connected = false,
+            VisibilityFilter::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
+                for entity in removed.drain() {
+                    list.remove(&entity);
+                }
+                added.clear();
+            }
+            VisibilityFilter::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                for entity in added.drain() {
+                    list.insert(entity, false);
+                }
+                removed.clear();
+            }
+        }
+    }
+
+    /// Removes a despawned entity tracked by this client.
+    pub(super) fn remove_despawned(&mut self, entity: Entity) {
+        match &mut self.0 {
+            VisibilityFilter::All { .. } => (),
+            VisibilityFilter::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
+                if let Some(just_removed) = list.get_mut(&entity) {
+                    *just_removed = true;
+                    removed.remove(&entity);
+                    added.remove(&entity);
+                }
+            }
+            VisibilityFilter::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                if list.remove(&entity).is_some() {
+                    added.remove(&entity);
+                    removed.remove(&entity);
+                }
+            }
+        }
+    }
+
+    /// Returns an iterator of entities that lost visibility at this tick.
+    pub(super) fn iter_lost_visibility(&self) -> impl Iterator<Item = Entity> + '_ {
+        match &self.0 {
+            VisibilityFilter::All { .. } => VisibilityLostIter::AllVisible,
+            VisibilityFilter::Blacklist { added, .. } => {
+                VisibilityLostIter::Lost(added.iter().copied())
+            }
+            VisibilityFilter::Whitelist { removed, .. } => {
+                VisibilityLostIter::Lost(removed.iter().copied())
+            }
+        }
+    }
+
+    /// Sets visibility for specific entity.
+    ///
+    /// Does nothing if visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
+    pub fn set_visible(&mut self, entity: Entity, visibile: bool) {
+        match &mut self.0 {
+            VisibilityFilter::All { .. } => {
+                if visibile {
+                    debug!(
+                        "ignoring visibility enable due to {:?}",
+                        VisibilityPolicy::All
+                    );
+                } else {
+                    warn!(
+                        "ignoring visibility disable due to {:?}",
+                        VisibilityPolicy::All
+                    );
+                }
+            }
+            VisibilityFilter::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
+                if !visibile {
+                    if list.insert(entity, false).is_none() {
+                        removed.remove(&entity);
+                        added.insert(entity);
+                    }
+                } else if list.remove(&entity).is_some() {
+                    removed.insert(entity);
+                    added.remove(&entity);
+                }
+            }
+            VisibilityFilter::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
+                if visibile {
+                    if list.insert(entity, true).is_none() {
+                        removed.remove(&entity);
+                        added.insert(entity);
+                    }
+                } else if list.remove(&entity).is_some() {
+                    removed.insert(entity);
+                    added.remove(&entity);
+                }
+            }
+        }
+    }
+
+    /// Gets visibility for specific entity.
+    pub fn is_visible(&self, entity: Entity) -> bool {
+        match &self.0 {
+            VisibilityFilter::All { .. } => true,
+            VisibilityFilter::Blacklist { list, .. } => !list.contains_key(&entity),
+            VisibilityFilter::Whitelist { list, .. } => list.contains_key(&entity),
+        }
+    }
+
+    /// Gets visibility with change information included for specific entity.
+    pub(crate) fn get_info(&self, entity: Entity) -> VisibilityInfo {
+        match &self.0 {
+            VisibilityFilter::All { just_connected } => {
+                if *just_connected {
+                    VisibilityInfo::Gained
+                } else {
+                    VisibilityInfo::Maintained
+                }
+            }
+            VisibilityFilter::Blacklist { list, .. } => match list.get(&entity) {
+                Some(true) => VisibilityInfo::Gained,
+                Some(false) => VisibilityInfo::None,
+                None => VisibilityInfo::Maintained,
+            },
+            VisibilityFilter::Whitelist { list, .. } => match list.get(&entity) {
+                Some(true) => VisibilityInfo::Gained,
+                Some(false) => VisibilityInfo::Maintained,
+                None => VisibilityInfo::None,
+            },
+        }
+    }
+}
+
+/// Since enums can't have private fields, it's wrapped into [`ClientVisibility`] to make fields private, while keeping the struct public.
+enum VisibilityFilter {
     All {
         /// Indicates that the client has just connected to the server.
         just_connected: bool,
@@ -27,201 +225,6 @@ pub enum ClientVisibility {
         /// All entities that were removed from the list on this tick.
         removed: EntityHashSet<Entity>,
     },
-}
-
-impl ClientVisibility {
-    /// Creates a new instance based on the preconfigured policy.
-    pub(super) fn new(policy: VisibilityPolicy) -> Self {
-        match policy {
-            VisibilityPolicy::All => Self::All {
-                just_connected: true,
-            },
-            VisibilityPolicy::Blacklist => Self::Blacklist {
-                list: Default::default(),
-                added: Default::default(),
-                removed: Default::default(),
-            },
-            VisibilityPolicy::Whitelist => Self::Whitelist {
-                list: Default::default(),
-                added: Default::default(),
-                removed: Default::default(),
-            },
-        }
-    }
-
-    /// Resets the state to as it was after [`Self::new`].
-    pub(super) fn clear(&mut self) {
-        match self {
-            ClientVisibility::All { just_connected } => *just_connected = true,
-            ClientVisibility::Blacklist {
-                list,
-                added,
-                removed,
-            }
-            | ClientVisibility::Whitelist {
-                list,
-                added,
-                removed,
-            } => {
-                list.clear();
-                added.clear();
-                removed.clear();
-            }
-        }
-    }
-
-    /// Marks all entities as not "just added" and clears the removed.
-    ///
-    /// Should be called after each tick.
-    pub(crate) fn update(&mut self) {
-        match self {
-            ClientVisibility::All { just_connected } => *just_connected = false,
-            ClientVisibility::Blacklist {
-                list,
-                added,
-                removed,
-            } => {
-                for entity in removed.drain() {
-                    list.remove(&entity);
-                }
-                added.clear();
-            }
-            ClientVisibility::Whitelist {
-                list,
-                added,
-                removed,
-            } => {
-                for entity in added.drain() {
-                    list.insert(entity, false);
-                }
-                removed.clear();
-            }
-        }
-    }
-
-    /// Removes a despawned entity tracked by this client.
-    pub(super) fn remove_despawned(&mut self, entity: Entity) {
-        match self {
-            ClientVisibility::All { .. } => (),
-            ClientVisibility::Blacklist {
-                list,
-                added,
-                removed,
-            } => {
-                if let Some(just_removed) = list.get_mut(&entity) {
-                    *just_removed = true;
-                    removed.remove(&entity);
-                    added.remove(&entity);
-                }
-            }
-            ClientVisibility::Whitelist {
-                list,
-                added,
-                removed,
-            } => {
-                if list.remove(&entity).is_some() {
-                    added.remove(&entity);
-                    removed.remove(&entity);
-                }
-            }
-        }
-    }
-
-    /// Returns an iterator of entities that lost visibility at this tick.
-    pub(super) fn iter_lost_visibility(&self) -> impl Iterator<Item = Entity> + '_ {
-        match self {
-            ClientVisibility::All { .. } => VisibilityLostIter::AllVisible,
-            ClientVisibility::Blacklist { added, .. } => {
-                VisibilityLostIter::Lost(added.iter().copied())
-            }
-            ClientVisibility::Whitelist { removed, .. } => {
-                VisibilityLostIter::Lost(removed.iter().copied())
-            }
-        }
-    }
-
-    /// Sets visibility for specific entity.
-    ///
-    /// Does nothing if visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
-    pub fn set_visible(&mut self, entity: Entity, visibile: bool) {
-        match self {
-            ClientVisibility::All { .. } => {
-                if visibile {
-                    debug!(
-                        "ignoring visibility enable due to {:?}",
-                        VisibilityPolicy::All
-                    );
-                } else {
-                    warn!(
-                        "ignoring visibility disable due to {:?}",
-                        VisibilityPolicy::All
-                    );
-                }
-            }
-            ClientVisibility::Blacklist {
-                list,
-                added,
-                removed,
-            } => {
-                if !visibile {
-                    if list.insert(entity, false).is_none() {
-                        removed.remove(&entity);
-                        added.insert(entity);
-                    }
-                } else if list.remove(&entity).is_some() {
-                    removed.insert(entity);
-                    added.remove(&entity);
-                }
-            }
-            ClientVisibility::Whitelist {
-                list,
-                added,
-                removed,
-            } => {
-                if visibile {
-                    if list.insert(entity, true).is_none() {
-                        removed.remove(&entity);
-                        added.insert(entity);
-                    }
-                } else if list.remove(&entity).is_some() {
-                    removed.insert(entity);
-                    added.remove(&entity);
-                }
-            }
-        }
-    }
-
-    /// Gets visibility for specific entity.
-    pub fn is_visible(&self, entity: Entity) -> bool {
-        match self {
-            ClientVisibility::All { .. } => true,
-            ClientVisibility::Blacklist { list, .. } => !list.contains_key(&entity),
-            ClientVisibility::Whitelist { list, .. } => list.contains_key(&entity),
-        }
-    }
-
-    /// Gets visibility with change information included for specific entity.
-    pub(crate) fn get_info(&self, entity: Entity) -> VisibilityInfo {
-        match self {
-            ClientVisibility::All { just_connected } => {
-                if *just_connected {
-                    VisibilityInfo::Gained
-                } else {
-                    VisibilityInfo::Maintained
-                }
-            }
-            ClientVisibility::Blacklist { list, .. } => match list.get(&entity) {
-                Some(true) => VisibilityInfo::Gained,
-                Some(false) => VisibilityInfo::None,
-                None => VisibilityInfo::Maintained,
-            },
-            ClientVisibility::Whitelist { list, .. } => match list.get(&entity) {
-                Some(true) => VisibilityInfo::Gained,
-                Some(false) => VisibilityInfo::Maintained,
-                None => VisibilityInfo::None,
-            },
-        }
-    }
 }
 
 #[derive(PartialEq)]

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -204,11 +204,9 @@ impl ClientVisibility {
                         added.insert(entity);
                     }
                     removed.remove(&entity);
-                } else if list.remove(&entity).is_some() {
-                    if !added.remove(&entity) {
-                        // If the entity wasn't previously added in this tick, then consider it removed.
-                        removed.insert(entity);
-                    }
+                } else if list.remove(&entity).is_some() && !added.remove(&entity) {
+                    // If the entity wasn't previously added in this tick, then consider it removed.
+                    removed.insert(entity);
                 }
             }
         }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -91,16 +91,21 @@ impl ClientVisibility {
 
     /// Sets visibility for specific entity.
     ///
-    /// # Panics
-    ///
-    /// Panics if the server plugin was previously configured with [`VisibilityPolicy::All`].
+    /// Does nothing if visibility policy for the server plugin is set to [`VisibilityPolicy::All`].
     pub fn set(&mut self, entity: Entity, visibile: bool) {
         match self {
             ClientVisibility::All { .. } => {
-                panic!(
-                    "visibility shouldn't be set with {:?}",
-                    VisibilityPolicy::All
-                )
+                if visibile {
+                    debug!(
+                        "ignoring visibility enable due to {:?}",
+                        VisibilityPolicy::All
+                    );
+                } else {
+                    warn!(
+                        "ignoring visibility disable due to {:?}",
+                        VisibilityPolicy::All
+                    );
+                }
             }
             ClientVisibility::Blacklist { list, removed } => {
                 if !visibile {

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -179,10 +179,10 @@ impl ClientVisibility {
                 removed,
             } => {
                 if visibile {
-                    /// Similar to Blacklist removal, we don't just add the entity to the list.
-                    /// Instead we mark it as 'just added' and then set it to 'visible' in `Self::update`.
-                    /// This allows us to avoid accessing the whitelist's `added` field in
-                    /// `Self::cache_visibility`.
+                    // Similar to blacklist removal, we don't just add the entity to the list.
+                    // Instead we mark it as 'just added' and then set it to 'visible' in `Self::update`.
+                    // This allows us to avoid accessing the whitelist's `added` field in
+                    // `Self::cache_visibility`.
                     if list.insert(entity, WhitelistInfo::JustAdded).is_none() {
                         // Do not mark an entry as newly added if the entry was already in the list.
                         added.insert(entity);

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -76,20 +76,28 @@ impl ClientVisibility {
     pub(crate) fn update(&mut self) {
         match &mut self.filter {
             VisibilityFilter::All { just_connected } => *just_connected = false,
-            VisibilityFilter::Blacklist { list, removed, .. } => {
+            VisibilityFilter::Blacklist {
+                list,
+                added,
+                removed,
+            } => {
                 // Remove all entities queued for removal.
                 for entity in removed.drain() {
                     list.remove(&entity);
                 }
-                // `added` is drained in `Self::drain_lost_visibility`.
+                added.clear();
             }
-            VisibilityFilter::Whitelist { list, added, .. } => {
+            VisibilityFilter::Whitelist {
+                list,
+                added,
+                removed,
+            } => {
                 // Change all recently added entities to `WhitelistInfo::Visible`
                 // from `WhitelistInfo::JustVisible`.
                 for entity in added.drain() {
                     list.insert(entity, WhitelistInfo::Visible);
                 }
-                // `removed` is drained in `Self::drain_lost_visibility`.
+                removed.clear();
             }
         }
     }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -242,24 +242,38 @@ impl ClientVisibility {
 enum VisibilityFilter {
     All {
         /// Indicates that the client has just connected to the server.
+        ///
+        /// If true, then visibility of all entities has been gained.
         just_connected: bool,
     },
     Blacklist {
         /// All blacklisted entities and an indicator of whether they are in the queue for deletion
         /// at the end of this tick.
         list: EntityHashMap<Entity, BlacklistInfo>,
+
         /// All entities that were removed from the list in this tick.
+        ///
+        /// Visibility of these entities has been lost.
         added: EntityHashSet<Entity>,
+
         /// All entities that were added to the list in this tick.
+        ///
+        /// Visibility of these entities has been gained.
         removed: EntityHashSet<Entity>,
     },
     Whitelist {
         /// All whitelisted entities and an indicator of whether they were added to the list in
         /// this tick.
         list: EntityHashMap<Entity, WhitelistInfo>,
-        /// All entities that were added to the list in this tick.
+
+        /// All entities that were added to the list in tVisibility of these entities has been gained.his tick.
+        ///
+        /// Visibility of these entities has been gained.
         added: EntityHashSet<Entity>,
+
         /// All entities that were removed from the list in this tick.
+        ///
+        /// Visibility of these entities has been lost.
         removed: EntityHashSet<Entity>,
     },
 }

--- a/src/server/clients_info/client_visibility.rs
+++ b/src/server/clients_info/client_visibility.rs
@@ -166,7 +166,8 @@ impl ClientVisibility {
                         added.remove(&entity);
                     }
                 } else {
-                    if list.insert(entity, BlacklistInfo::Hidden).is_none() {
+                    if *list.entry(entity).or_insert(BlacklistInfo::Hidden) == BlacklistInfo::Hidden
+                    {
                         // Do not mark an entry as newly added if the entry was already in the list.
                         added.insert(entity);
                     }
@@ -183,7 +184,9 @@ impl ClientVisibility {
                     // Instead we mark it as 'just added' and then set it to 'visible' in `Self::update`.
                     // This allows us to avoid accessing the whitelist's `added` field in
                     // `Self::cache_visibility`.
-                    if list.insert(entity, WhitelistInfo::JustAdded).is_none() {
+                    if *list.entry(entity).or_insert(WhitelistInfo::JustAdded)
+                        == WhitelistInfo::JustAdded
+                    {
                         // Do not mark an entry as newly added if the entry was already in the list.
                         added.insert(entity);
                     }
@@ -278,11 +281,13 @@ enum VisibilityFilter {
     },
 }
 
+#[derive(PartialEq, Clone, Copy)]
 enum WhitelistInfo {
     Visible,
     JustAdded,
 }
 
+#[derive(PartialEq, Clone, Copy)]
 enum BlacklistInfo {
     Hidden,
     QueuedForRemoval,

--- a/src/server/replication_messages.rs
+++ b/src/server/replication_messages.rs
@@ -94,6 +94,7 @@ impl ReplicationMessages {
                 tick,
                 timestamp,
             )?;
+            client_info.visibility_mut().update();
         }
 
         let clients_info = mem::take(&mut self.clients_info);

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -677,6 +677,7 @@ fn update_replication_cleanup() {
             ReplicationPlugins.set(ServerPlugin {
                 tick_policy: TickPolicy::EveryFrame,
                 update_timeout: Duration::ZERO, // Will cause dropping updates after each frame.
+                ..Default::default()
             }),
         ))
         .replicate::<BoolComponent>();

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -988,6 +988,43 @@ fn whitelist_visibility() {
 }
 
 #[test]
+fn whitelist_despawn_visibility() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                visibility_policy: VisibilityPolicy::Whitelist,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+
+    let client_transport = client_app.world.resource::<NetcodeClientTransport>();
+    let client_id = ClientId::from_raw(client_transport.client_id());
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
+    visibility.set_visibility(server_entity, true);
+    server_app.world.despawn(server_entity);
+
+    server_app.update();
+    client_app.update();
+
+    assert!(client_app.world.entities().is_empty());
+
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
+    assert!(!visibility.is_visible(server_entity));
+}
+
+#[test]
 fn replication_into_scene() {
     let mut app = App::new();
     app.add_plugins(ReplicationPlugins)

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -905,8 +905,8 @@ fn blacklist_despawn_visibility() {
 
     assert!(client_app.world.entities().is_empty());
 
-    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.client_mut(client_id).visibility_mut();
+    let clients_info = server_app.world.resource::<ClientsInfo>();
+    let visibility = clients_info.client(client_id).visibility();
     assert!(visibility.is_visible(server_entity)); // The missing entity must be removed from the list, so this should return `true`.
 }
 
@@ -1019,8 +1019,8 @@ fn whitelist_despawn_visibility() {
 
     assert!(client_app.world.entities().is_empty());
 
-    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.client_mut(client_id).visibility_mut();
+    let clients_info = server_app.world.resource::<ClientsInfo>();
+    let visibility = clients_info.client(client_id).visibility();
     assert!(!visibility.is_visible(server_entity));
 }
 

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -789,7 +789,7 @@ fn all_replication() {
     // Reverse visibility.
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, true);
+    visibility.set_visible(server_entity, false);
     assert!(
         visibility.is_visible(server_entity),
         "shouldn't have any effect with {:?}",

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -753,6 +753,178 @@ fn update_replication_cleanup() {
 }
 
 #[test]
+fn all_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+
+    let client_transport = client_app.world.resource::<NetcodeClientTransport>();
+    let client_id = ClientId::from_raw(client_transport.client_id());
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(server_entity, true);
+    assert!(visibility.is_visible(server_entity));
+
+    server_app.update();
+    client_app.update();
+
+    client_app
+        .world
+        .query_filtered::<(), (With<Replication>, With<TableComponent>)>()
+        .single(&client_app.world);
+
+    // Reverse visibility.
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(server_entity, true);
+    assert!(
+        visibility.is_visible(server_entity),
+        "shouldn't have any effect with {:?}",
+        VisibilityPolicy::All
+    );
+
+    server_app.update();
+    client_app.update();
+
+    client_app
+        .world
+        .query_filtered::<(), (With<Replication>, With<TableComponent>)>()
+        .single(&client_app.world);
+}
+
+#[test]
+fn blacklist_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                visibility_policy: VisibilityPolicy::Blacklist,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let hidden_entity = server_app.world.spawn((Replication, TableComponent)).id();
+
+    let client_transport = client_app.world.resource::<NetcodeClientTransport>();
+    let client_id = ClientId::from_raw(client_transport.client_id());
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(hidden_entity, false);
+    assert!(visibility.is_visible(server_entity));
+    assert!(!visibility.is_visible(hidden_entity));
+
+    server_app.update();
+    client_app.update();
+
+    let client_entity = client_app
+        .world
+        .query_filtered::<Entity, (With<Replication>, With<TableComponent>)>()
+        .single(&client_app.world);
+
+    let entity_map = client_app.world.resource::<ServerEntityMap>();
+    assert_eq!(
+        entity_map.to_client().get(&server_entity),
+        Some(&client_entity),
+    );
+
+    // Reverse visibility.
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(hidden_entity, true);
+
+    server_app.update();
+    client_app.update();
+
+    let entities_count = client_app
+        .world
+        .query_filtered::<Entity, (With<Replication>, With<TableComponent>)>()
+        .iter(&client_app.world)
+        .count();
+    assert_eq!(
+        entities_count, 2,
+        "hidden entity should be spawned on client after removing from blacklist"
+    );
+}
+
+#[test]
+fn whitelist_replication() {
+    let mut server_app = App::new();
+    let mut client_app = App::new();
+    for app in [&mut server_app, &mut client_app] {
+        app.add_plugins((
+            MinimalPlugins,
+            ReplicationPlugins.set(ServerPlugin {
+                tick_policy: TickPolicy::EveryFrame,
+                visibility_policy: VisibilityPolicy::Whitelist,
+                ..Default::default()
+            }),
+        ))
+        .replicate::<TableComponent>();
+    }
+
+    connect::single_client(&mut server_app, &mut client_app);
+
+    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let hidden_entity = server_app.world.spawn((Replication, TableComponent)).id();
+
+    let client_transport = client_app.world.resource::<NetcodeClientTransport>();
+    let client_id = ClientId::from_raw(client_transport.client_id());
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(server_entity, true);
+    assert!(visibility.is_visible(server_entity));
+    assert!(!visibility.is_visible(hidden_entity));
+
+    server_app.update();
+    client_app.update();
+
+    let client_entity = client_app
+        .world
+        .query_filtered::<Entity, (With<Replication>, With<TableComponent>)>()
+        .single(&client_app.world);
+
+    let entity_map = client_app.world.resource::<ServerEntityMap>();
+    assert_eq!(
+        entity_map.to_client().get(&server_entity),
+        Some(&client_entity),
+    );
+
+    // Reverse visibility.
+    let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
+    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    visibility.set_visible(server_entity, false);
+
+    server_app.update();
+    client_app.update();
+
+    assert!(
+        client_app.world.entities().is_empty(),
+        "server entity should be despawned after removing from whitelist"
+    );
+}
+
+#[test]
 fn replication_into_scene() {
     let mut app = App::new();
     app.add_plugins(ReplicationPlugins)

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -775,14 +775,14 @@ fn all_visibility() {
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, false);
+    visibility.set_visibility(server_entity, false);
     assert!(
         visibility.is_visible(server_entity),
         "shouldn't have any effect with {:?}",
         VisibilityPolicy::All
     );
 
-    visibility.set_visible(server_entity, true);
+    visibility.set_visibility(server_entity, true);
     assert!(visibility.is_visible(server_entity));
 }
 
@@ -845,7 +845,7 @@ fn blacklist_visibility_add_remove() {
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, false);
+    visibility.set_visibility(server_entity, false);
     assert!(!visibility.is_visible(server_entity));
 
     server_app.update();
@@ -856,7 +856,7 @@ fn blacklist_visibility_add_remove() {
     // Reverse visibility back.
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, true);
+    visibility.set_visibility(server_entity, true);
 
     server_app.update();
     client_app.update();
@@ -926,7 +926,7 @@ fn whitelist_visibility_add_remove() {
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, true);
+    visibility.set_visibility(server_entity, true);
     assert!(visibility.is_visible(server_entity));
 
     server_app.update();
@@ -940,7 +940,7 @@ fn whitelist_visibility_add_remove() {
     // Reverse visibility.
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
     let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
-    visibility.set_visible(server_entity, false);
+    visibility.set_visibility(server_entity, false);
 
     server_app.update();
     client_app.update();

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -891,7 +891,7 @@ fn blacklist_despawn_visibility() {
 
     connect::single_client(&mut server_app, &mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let server_entity = server_app.world.spawn(Replication).id();
 
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
@@ -1005,7 +1005,7 @@ fn whitelist_despawn_visibility() {
 
     connect::single_client(&mut server_app, &mut client_app);
 
-    let server_entity = server_app.world.spawn((Replication, TableComponent)).id();
+    let server_entity = server_app.world.spawn(Replication).id();
 
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());

--- a/tests/replication.rs
+++ b/tests/replication.rs
@@ -774,7 +774,7 @@ fn all_visibility() {
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
     assert!(
         visibility.is_visible(server_entity),
@@ -809,7 +809,7 @@ fn blacklist_visibility() {
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
     let clients_info = server_app.world.resource::<ClientsInfo>();
-    let visibility = clients_info.get(client_id).unwrap().visibility();
+    let visibility = clients_info.client(client_id).visibility();
     assert!(visibility.is_visible(server_entity));
 
     server_app.update();
@@ -844,7 +844,7 @@ fn blacklist_visibility_add_remove() {
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
     assert!(!visibility.is_visible(server_entity));
 
@@ -855,7 +855,7 @@ fn blacklist_visibility_add_remove() {
 
     // Reverse visibility back.
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
 
     server_app.update();
@@ -890,7 +890,7 @@ fn whitelist_visibility() {
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
     let clients_info = server_app.world.resource::<ClientsInfo>();
-    let visibility = clients_info.get(client_id).unwrap().visibility();
+    let visibility = clients_info.client(client_id).visibility();
     assert!(!visibility.is_visible(server_entity));
 
     server_app.update();
@@ -925,7 +925,7 @@ fn whitelist_visibility_add_remove() {
     let client_transport = client_app.world.resource::<NetcodeClientTransport>();
     let client_id = ClientId::from_raw(client_transport.client_id());
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, true);
     assert!(visibility.is_visible(server_entity));
 
@@ -939,7 +939,7 @@ fn whitelist_visibility_add_remove() {
 
     // Reverse visibility.
     let mut clients_info = server_app.world.resource_mut::<ClientsInfo>();
-    let visibility = clients_info.get_mut(client_id).unwrap().visibility_mut();
+    let visibility = clients_info.client_mut(client_id).visibility_mut();
     visibility.set_visibility(server_entity, false);
 
     server_app.update();


### PR DESCRIPTION
## Description

It's a prototype of my recent idea about visibility management. Please note, that it's a quick and dirty prototype, I just wanted to showcase the idea.

The idea is simple. When you configure server plugin, you set visibility policy based on your game. Then you can control visibility using `ClientVisibility` struct obtainable from `ClientInfo`. `ClientVisibility` is an enum with fields based on policy:
- `ClientVisibility::All`: stores only single boolean to check if client just connected.
- `ClientVisibility::Whitelist` / `ClientVisibility::Blacklist`:
    - A list of entities with a boolean value for each one if it was just added.
    - A set of removed entities from the list above.

When we collect changes, we also check if an entity visible or just became visible for specific client (can be optimized, see below).
When we collect removals, we additionally iterate over just hidden entities.

TODO:
- [x] Discuss the design itself.
- [x] Optimizations.
- [x] More docs.
- [x] Tests.

## Advantages

- No performance cost if game doesn't need visibility management at all.
- Lower cost compared to #15 if game need one room per entity.
- Extensible, more high level API like #15 can be implemented on top of it.

## Disadvantages

- If your game benefit from managing visibility for group of entities, the API will fill more barebones compared to the proposed rooms API.

## Optimizations

- I create a boxed iterator for despawns. Can we use different API to avoid this allocation?
- I do an entity lookup for each component. Can I cache the lookup using an Option? Or maybe restructure the loop? Not specific to the idea itself, same would be about rooms API.
- For blacklist option I iterate over each entity. Maybe I can use a separate storage for just added entities? But it will add an extra lookup for getting visibility (to check if an entity was just added or not).